### PR TITLE
feat: add shared env configuration

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -17,6 +17,9 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  experimental: {
+    externalDir: true,
+  },
 };
 
 export default nextConfig;

--- a/client/src/app/(auth)/authProvider.tsx
+++ b/client/src/app/(auth)/authProvider.tsx
@@ -12,14 +12,14 @@ import {
 } from "@aws-amplify/ui-react";
 import "@aws-amplify/ui-react/styles.css";
 import { useRouter, usePathname } from "next/navigation";
+import { env } from "../../../../packages/shared/config/env";
 
 // https://docs.amplify.aws/gen1/javascript/tools/libraries/configure-categories/
 Amplify.configure({
   Auth: {
     Cognito: {
-      userPoolId: process.env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID!,
-      userPoolClientId:
-        process.env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID!,
+      userPoolId: env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID,
+      userPoolClientId: env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID,
     },
   },
 });

--- a/client/src/app/(nondashboard)/landing/HeroSection.tsx
+++ b/client/src/app/(nondashboard)/landing/HeroSection.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { useDispatch } from "react-redux";
 import { useRouter } from "next/navigation";
 import { setFilters } from "@/state";
+import { env } from "../../../../../packages/shared/config/env";
 
 const HeroSection = () => {
   const dispatch = useDispatch();
@@ -23,7 +24,7 @@ const HeroSection = () => {
         `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(
           trimmedQuery
         )}.json?access_token=${
-          process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+          env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
         }&fuzzyMatch=true`
       );
       const data = await response.json();

--- a/client/src/app/(nondashboard)/search/FiltersBar.tsx
+++ b/client/src/app/(nondashboard)/search/FiltersBar.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { PropertyTypeIcons } from "@/lib/constants";
+import { env } from "../../../../../packages/shared/config/env";
 
 const FiltersBar = () => {
   const dispatch = useDispatch();
@@ -78,7 +79,7 @@ const FiltersBar = () => {
         `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(
           searchInput
         )}.json?access_token=${
-          process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+          env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
         }&fuzzyMatch=true`
       );
       const data = await response.json();

--- a/client/src/app/(nondashboard)/search/FiltersFull.tsx
+++ b/client/src/app/(nondashboard)/search/FiltersFull.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
+import { env } from "../../../../../packages/shared/config/env";
 
 const FiltersFull = () => {
   const dispatch = useDispatch();
@@ -69,7 +70,7 @@ const FiltersFull = () => {
         `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(
           localFilters.location
         )}.json?access_token=${
-          process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+          env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
         }&fuzzyMatch=true`
       );
       const data = await response.json();

--- a/client/src/app/(nondashboard)/search/Map.tsx
+++ b/client/src/app/(nondashboard)/search/Map.tsx
@@ -5,8 +5,9 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import { useAppSelector } from "@/state/redux";
 import { useGetPropertiesQuery } from "@/state/api";
 import { Property } from "@/types/prismaTypes";
+import { env } from "../../../../../packages/shared/config/env";
 
-mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
+mapboxgl.accessToken = env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
 const Map = () => {
   const mapContainerRef = useRef(null);

--- a/client/src/app/(nondashboard)/search/[id]/PropertyLocation.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyLocation.tsx
@@ -3,8 +3,9 @@ import { Compass, MapPin } from "lucide-react";
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import React, { useEffect, useRef } from "react";
+import { env } from "../../../../../../packages/shared/config/env";
 
-mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
+mapboxgl.accessToken = env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
 const PropertyLocation = ({ propertyId }: PropertyDetailsProps) => {
   const {

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -10,10 +10,11 @@ import {
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { fetchAuthSession, getCurrentUser } from "aws-amplify/auth";
 import { FiltersState } from ".";
+import { env } from "../../../packages/shared/config/env";
 
 export const api = createApi({
   baseQuery: fetchBaseQuery({
-    baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+    baseUrl: env.NEXT_PUBLIC_API_BASE_URL,
     prepareHeaders: async (headers) => {
       const session = await fetchAuthSession();
       const { idToken } = session.tokens ?? {};

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,13 @@
+# Environment Variables
+
+The application relies on the following environment variables. All are validated at startup using a shared Zod schema to ensure the application fails fast when misconfigured.
+
+| Variable | Description |
+| --- | --- |
+| `NEXT_PUBLIC_API_BASE_URL` | Base URL for client API requests. |
+| `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` | Mapbox access token used for map components. |
+| `NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID` | AWS Cognito user pool identifier for authentication. |
+| `NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID` | AWS Cognito user pool client ID for authentication. |
+| `AWS_REGION` | AWS region used by the server when interacting with AWS services. |
+| `S3_BUCKET_NAME` | Name of the S3 bucket storing property images. |
+| `PORT` | Port for the Express server (defaults to `3002`). |

--- a/packages/shared/config/env.ts
+++ b/packages/shared/config/env.ts
@@ -1,0 +1,17 @@
+import { config } from "dotenv";
+import { z } from "zod";
+
+config();
+
+const envSchema = z.object({
+  NEXT_PUBLIC_API_BASE_URL: z.string().url(),
+  NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: z.string().min(1),
+  NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID: z.string().min(1),
+  NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID: z.string().min(1),
+  AWS_REGION: z.string().min(1),
+  S3_BUCKET_NAME: z.string().min(1),
+  PORT: z.coerce.number().int().default(3002),
+});
+
+export const env = envSchema.parse(process.env);
+export type Env = z.infer<typeof envSchema>;

--- a/packages/shared/package-lock.json
+++ b/packages/shared/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "@real-estate/shared",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@real-estate/shared",
+      "version": "1.0.0",
+      "dependencies": {
+        "dotenv": "^16.4.7",
+        "zod": "^3.24.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@real-estate/shared",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "dotenv": "^16.4.7",
+    "zod": "^3.24.1"
+  }
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,7 +23,8 @@
         "morgan": "^1.10.0",
         "multer": "^1.4.5-lts.1",
         "prisma": "^6.3.0",
-        "uuid": "^11.0.5"
+        "uuid": "^11.0.5",
+        "zod": "^3.24.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -4911,6 +4912,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,8 @@
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
     "prisma": "^6.3.0",
-    "uuid": "^11.0.5"
+    "uuid": "^11.0.5",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -5,11 +5,12 @@ import { S3Client } from "@aws-sdk/client-s3";
 import { Location } from "@prisma/client";
 import { Upload } from "@aws-sdk/lib-storage";
 import axios from "axios";
+import { env } from "../../../packages/shared/config/env";
 
 const prisma = new PrismaClient();
 
 const s3Client = new S3Client({
-  region: process.env.AWS_REGION,
+  region: env.AWS_REGION,
 });
 
 export const getProperties = async (
@@ -209,7 +210,7 @@ export const createProperty = async (
     const photoUrls = await Promise.all(
       files.map(async (file) => {
         const uploadParams = {
-          Bucket: process.env.S3_BUCKET_NAME!,
+          Bucket: env.S3_BUCKET_NAME,
           Key: `properties/${Date.now()}-${file.originalname}`,
           Body: file.buffer,
           ContentType: file.mimetype,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,9 +1,9 @@
 import express from "express";
-import dotenv from "dotenv";
 import bodyParser from "body-parser";
 import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
+import { env } from "../../packages/shared/config/env";
 import { authMiddleware } from "./middleware/authMiddleware";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenantRoutes";
@@ -13,7 +13,6 @@ import leaseRoutes from "./routes/leaseRoutes";
 import applicationRoutes from "./routes/applicationRoutes";
 
 /* CONFIGURATIONS */
-dotenv.config();
 const app = express();
 app.use(express.json());
 app.use(helmet());
@@ -35,7 +34,7 @@ app.use("/tenants", authMiddleware(["tenant"]), tenantRoutes);
 app.use("/managers", authMiddleware(["manager"]), managerRoutes);
 
 /* SERVER */
-const port = Number(process.env.PORT) || 3002;
+const port = env.PORT;
 app.listen(port, "0.0.0.0", () => {
   console.log(`Server running on port ${port}`);
 });


### PR DESCRIPTION
## Summary
- validate environment variables with shared Zod schema
- use typed env object across client and server
- document required environment variables

## Testing
- `cd server && npm run build`
- `cd client && npm run build` *(fails: interrupted after type checking due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68a97d7617a88328b18e815e15e00aa6