### PR TITLE
Add global error and not-found pages

### DIFF
--- a/client/src/app/error.tsx
+++ b/client/src/app/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 text-center">
+      <h2 className="text-2xl font-semibold">Something went wrong</h2>
+      <div className="flex gap-4">
+        <button onClick={() => reset()} className="underline">
+          Try again
+        </button>
+        <Link href="/search" className="underline">
+          Search listings
+        </Link>
+        <Link href="/" className="underline">
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/client/src/app/not-found.tsx
+++ b/client/src/app/not-found.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 text-center">
+      <h2 className="text-2xl font-semibold">Page not found</h2>
+      <div className="flex gap-4">
+        <Link href="/search" className="underline">
+          Search listings
+        </Link>
+        <Link href="/" className="underline">
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add app-level error boundary component with retry and navigation links
- add custom 404 page with links back to search and home

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a97d7850148328b553258bbf9eff1e