### PR TITLE
feat: add path aliases for client and server

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
   images: {
@@ -16,6 +17,14 @@ const nextConfig: NextConfig = {
         pathname: "/**",
       },
     ],
+  },
+  webpack: (config) => {
+    config.resolve.alias["@client"] = path.resolve(__dirname, "src");
+    config.resolve.alias["@server"] = path.resolve(
+      __dirname,
+      "../server/src"
+    );
+    return config;
   },
 };
 

--- a/client/src/app/(dashboard)/layout.tsx
+++ b/client/src/app/(dashboard)/layout.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import Navbar from "@/components/Navbar";
-import { SidebarProvider } from "@/components/ui/sidebar";
-import Sidebar from "@/components/AppSidebar";
-import { NAVBAR_HEIGHT } from "@/lib/constants";
+import Navbar from "@client/components/Navbar";
+import { SidebarProvider } from "@client/components/ui/sidebar";
+import Sidebar from "@client/components/AppSidebar";
+import { NAVBAR_HEIGHT } from "@client/lib/constants";
 import React, { useEffect, useState } from "react";
-import { useGetAuthUserQuery } from "@/state/api";
+import { useGetAuthUserQuery } from "@client/state/api";
 import { usePathname, useRouter } from "next/navigation";
 
 const DashboardLayout = ({ children }: { children: React.ReactNode }) => {

--- a/client/src/app/(dashboard)/managers/applications/page.tsx
+++ b/client/src/app/(dashboard)/managers/applications/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import ApplicationCard from "@/components/ApplicationCard";
-import Header from "@/components/Header";
-import Loading from "@/components/Loading";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import ApplicationCard from "@client/components/ApplicationCard";
+import Header from "@client/components/Header";
+import Loading from "@client/components/Loading";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@client/components/ui/tabs";
 import {
   useGetApplicationsQuery,
   useGetAuthUserQuery,
   useUpdateApplicationStatusMutation,
-} from "@/state/api";
+} from "@client/state/api";
 import { CircleCheckBig, Download, File, Hospital } from "lucide-react";
 import Link from "next/link";
 import React, { useState } from "react";

--- a/client/src/app/(dashboard)/managers/newproperty/page.tsx
+++ b/client/src/app/(dashboard)/managers/newproperty/page.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { CustomFormField } from "@/components/FormField";
-import Header from "@/components/Header";
-import { Form } from "@/components/ui/form";
-import { PropertyFormData, propertySchema } from "@/lib/schemas";
-import { useCreatePropertyMutation, useGetAuthUserQuery } from "@/state/api";
-import { AmenityEnum, HighlightEnum, PropertyTypeEnum } from "@/lib/constants";
+import { CustomFormField } from "@client/components/FormField";
+import Header from "@client/components/Header";
+import { Form } from "@client/components/ui/form";
+import { PropertyFormData, propertySchema } from "@client/lib/schemas";
+import { useCreatePropertyMutation, useGetAuthUserQuery } from "@client/state/api";
+import { AmenityEnum, HighlightEnum, PropertyTypeEnum } from "@client/lib/constants";
 import { zodResolver } from "@hookform/resolvers/zod";
 import React from "react";
 import { useForm } from "react-hook-form";
-import { Button } from "@/components/ui/button";
+import { Button } from "@client/components/ui/button";
 
 const NewProperty = () => {
   const [createProperty] = useCreatePropertyMutation();

--- a/client/src/app/(dashboard)/managers/properties/[id]/page.tsx
+++ b/client/src/app/(dashboard)/managers/properties/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Header from "@/components/Header";
-import Loading from "@/components/Loading";
+import Header from "@client/components/Header";
+import Loading from "@client/components/Loading";
 import {
   Table,
   TableBody,
@@ -9,12 +9,12 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/ui/table";
+} from "@client/components/ui/table";
 import {
   useGetPaymentsQuery,
   useGetPropertyLeasesQuery,
   useGetPropertyQuery,
-} from "@/state/api";
+} from "@client/state/api";
 import { ArrowDownToLine, ArrowLeft, Check, Download } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";

--- a/client/src/app/(dashboard)/managers/properties/page.tsx
+++ b/client/src/app/(dashboard)/managers/properties/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import Card from "@/components/Card";
-import Header from "@/components/Header";
-import Loading from "@/components/Loading";
-import { useGetAuthUserQuery, useGetManagerPropertiesQuery } from "@/state/api";
+import Card from "@client/components/Card";
+import Header from "@client/components/Header";
+import Loading from "@client/components/Loading";
+import { useGetAuthUserQuery, useGetManagerPropertiesQuery } from "@client/state/api";
 import React from "react";
 
 const Properties = () => {

--- a/client/src/app/(dashboard)/managers/settings/page.tsx
+++ b/client/src/app/(dashboard)/managers/settings/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import SettingsForm from "@/components/SettingsForm";
+import SettingsForm from "@client/components/SettingsForm";
 import {
   useGetAuthUserQuery,
   useUpdateManagerSettingsMutation,
-} from "@/state/api";
+} from "@client/state/api";
 import React from "react";
 
 const ManagerSettings = () => {

--- a/client/src/app/(dashboard)/tenants/applications/page.tsx
+++ b/client/src/app/(dashboard)/tenants/applications/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import ApplicationCard from "@/components/ApplicationCard";
-import Header from "@/components/Header";
-import Loading from "@/components/Loading";
-import { useGetApplicationsQuery, useGetAuthUserQuery } from "@/state/api";
+import ApplicationCard from "@client/components/ApplicationCard";
+import Header from "@client/components/Header";
+import Loading from "@client/components/Loading";
+import { useGetApplicationsQuery, useGetAuthUserQuery } from "@client/state/api";
 import { CircleCheckBig, Clock, Download, XCircle } from "lucide-react";
 import React from "react";
 

--- a/client/src/app/(dashboard)/tenants/favorites/page.tsx
+++ b/client/src/app/(dashboard)/tenants/favorites/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import Card from "@/components/Card";
-import Header from "@/components/Header";
-import Loading from "@/components/Loading";
+import Card from "@client/components/Card";
+import Header from "@client/components/Header";
+import Loading from "@client/components/Loading";
 import {
   useGetAuthUserQuery,
   useGetPropertiesQuery,
   useGetTenantQuery,
-} from "@/state/api";
+} from "@client/state/api";
 import React from "react";
 
 const Favorites = () => {

--- a/client/src/app/(dashboard)/tenants/residences/[id]/page.tsx
+++ b/client/src/app/(dashboard)/tenants/residences/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Loading from "@/components/Loading";
+import Loading from "@client/components/Loading";
 import {
   Table,
   TableBody,
@@ -8,14 +8,14 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/ui/table";
+} from "@client/components/ui/table";
 import {
   useGetAuthUserQuery,
   useGetLeasesQuery,
   useGetPaymentsQuery,
   useGetPropertyQuery,
-} from "@/state/api";
-import { Lease, Payment, Property } from "@/types/prismaTypes";
+} from "@client/state/api";
+import { Lease, Payment, Property } from "@client/types/prismaTypes";
 import {
   ArrowDownToLineIcon,
   Check,

--- a/client/src/app/(dashboard)/tenants/residences/page.tsx
+++ b/client/src/app/(dashboard)/tenants/residences/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import Card from "@/components/Card";
-import Header from "@/components/Header";
-import Loading from "@/components/Loading";
+import Card from "@client/components/Card";
+import Header from "@client/components/Header";
+import Loading from "@client/components/Loading";
 import {
   useGetAuthUserQuery,
   useGetCurrentResidencesQuery,
   useGetTenantQuery,
-} from "@/state/api";
+} from "@client/state/api";
 import React from "react";
 
 const Residences = () => {

--- a/client/src/app/(dashboard)/tenants/settings/page.tsx
+++ b/client/src/app/(dashboard)/tenants/settings/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import SettingsForm from "@/components/SettingsForm";
+import SettingsForm from "@client/components/SettingsForm";
 import {
   useGetAuthUserQuery,
   useUpdateTenantSettingsMutation,
-} from "@/state/api";
+} from "@client/state/api";
 import React from "react";
 
 const TenantSettings = () => {

--- a/client/src/app/(nondashboard)/landing/HeroSection.tsx
+++ b/client/src/app/(nondashboard)/landing/HeroSection.tsx
@@ -3,11 +3,11 @@
 import Image from "next/image";
 import React, { useState } from "react";
 import { motion } from "framer-motion";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
+import { Input } from "@client/components/ui/input";
+import { Button } from "@client/components/ui/button";
 import { useDispatch } from "react-redux";
 import { useRouter } from "next/navigation";
-import { setFilters } from "@/state";
+import { setFilters } from "@client/state";
 
 const HeroSection = () => {
   const dispatch = useDispatch();

--- a/client/src/app/(nondashboard)/landing/page.tsx
+++ b/client/src/app/(nondashboard)/landing/page.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import HeroSection from "./HeroSection";
-import FeaturesSection from "./FeaturesSection";
-import DiscoverSection from "./DiscoverSection";
-import CallToActionSection from "./CallToActionSection";
-import FooterSection from "./FooterSection";
+import HeroSection from "@client/app/(nondashboard)/landing/HeroSection";
+import FeaturesSection from "@client/app/(nondashboard)/landing/FeaturesSection";
+import DiscoverSection from "@client/app/(nondashboard)/landing/DiscoverSection";
+import CallToActionSection from "@client/app/(nondashboard)/landing/CallToActionSection";
+import FooterSection from "@client/app/(nondashboard)/landing/FooterSection";
 
 const Landing = () => {
   return (

--- a/client/src/app/(nondashboard)/layout.tsx
+++ b/client/src/app/(nondashboard)/layout.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Navbar from "@/components/Navbar";
-import { NAVBAR_HEIGHT } from "@/lib/constants";
-import { useGetAuthUserQuery } from "@/state/api";
+import Navbar from "@client/components/Navbar";
+import { NAVBAR_HEIGHT } from "@client/lib/constants";
+import { useGetAuthUserQuery } from "@client/state/api";
 import { usePathname, useRouter } from "next/navigation";
 import React, { useEffect, useState } from "react";
 

--- a/client/src/app/(nondashboard)/search/FiltersBar.tsx
+++ b/client/src/app/(nondashboard)/search/FiltersBar.tsx
@@ -3,24 +3,24 @@ import {
   setFilters,
   setViewMode,
   toggleFiltersFullOpen,
-} from "@/state";
-import { useAppSelector } from "@/state/redux";
+} from "@client/state";
+import { useAppSelector } from "@client/state/redux";
 import { usePathname, useRouter } from "next/navigation";
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { debounce } from "lodash";
-import { cleanParams, cn, formatPriceValue } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
+import { cleanParams, cn, formatPriceValue } from "@client/lib/utils";
+import { Button } from "@client/components/ui/button";
 import { Filter, Grid, List, Search } from "lucide-react";
-import { Input } from "@/components/ui/input";
+import { Input } from "@client/components/ui/input";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
-import { PropertyTypeIcons } from "@/lib/constants";
+} from "@client/components/ui/select";
+import { PropertyTypeIcons } from "@client/lib/constants";
 
 const FiltersBar = () => {
   const dispatch = useDispatch();

--- a/client/src/app/(nondashboard)/search/FiltersFull.tsx
+++ b/client/src/app/(nondashboard)/search/FiltersFull.tsx
@@ -1,23 +1,23 @@
-import { FiltersState, initialState, setFilters } from "@/state";
-import { useAppSelector } from "@/state/redux";
+import { FiltersState, initialState, setFilters } from "@client/state";
+import { useAppSelector } from "@client/state/redux";
 import { usePathname, useRouter } from "next/navigation";
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { debounce } from "lodash";
-import { cleanParams, cn, formatEnumString } from "@/lib/utils";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
+import { cleanParams, cn, formatEnumString } from "@client/lib/utils";
+import { Input } from "@client/components/ui/input";
+import { Button } from "@client/components/ui/button";
 import { Search } from "lucide-react";
-import { AmenityIcons, PropertyTypeIcons } from "@/lib/constants";
-import { Slider } from "@/components/ui/slider";
+import { AmenityIcons, PropertyTypeIcons } from "@client/lib/constants";
+import { Slider } from "@client/components/ui/slider";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
-import { Label } from "@/components/ui/label";
+} from "@client/components/ui/select";
+import { Label } from "@client/components/ui/label";
 
 const FiltersFull = () => {
   const dispatch = useDispatch();

--- a/client/src/app/(nondashboard)/search/Listings.tsx
+++ b/client/src/app/(nondashboard)/search/Listings.tsx
@@ -4,12 +4,12 @@ import {
   useGetPropertiesQuery,
   useGetTenantQuery,
   useRemoveFavoritePropertyMutation,
-} from "@/state/api";
-import { useAppSelector } from "@/state/redux";
-import { Property } from "@/types/prismaTypes";
-import Card from "@/components/Card";
+} from "@client/state/api";
+import { useAppSelector } from "@client/state/redux";
+import { Property } from "@client/types/prismaTypes";
+import Card from "@client/components/Card";
 import React from "react";
-import CardCompact from "@/components/CardCompact";
+import CardCompact from "@client/components/CardCompact";
 
 const Listings = () => {
   const { data: authUser } = useGetAuthUserQuery();

--- a/client/src/app/(nondashboard)/search/Map.tsx
+++ b/client/src/app/(nondashboard)/search/Map.tsx
@@ -2,9 +2,9 @@
 import React, { useEffect, useRef } from "react";
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
-import { useAppSelector } from "@/state/redux";
-import { useGetPropertiesQuery } from "@/state/api";
-import { Property } from "@/types/prismaTypes";
+import { useAppSelector } from "@client/state/redux";
+import { useGetPropertiesQuery } from "@client/state/api";
+import { Property } from "@client/types/prismaTypes";
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
 

--- a/client/src/app/(nondashboard)/search/[id]/ApplicationModal.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/ApplicationModal.tsx
@@ -1,14 +1,14 @@
-import { CustomFormField } from "@/components/FormField";
-import { Button } from "@/components/ui/button";
+import { CustomFormField } from "@client/components/FormField";
+import { Button } from "@client/components/ui/button";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
-import { Form } from "@/components/ui/form";
-import { ApplicationFormData, applicationSchema } from "@/lib/schemas";
-import { useCreateApplicationMutation, useGetAuthUserQuery } from "@/state/api";
+} from "@client/components/ui/dialog";
+import { Form } from "@client/components/ui/form";
+import { ApplicationFormData, applicationSchema } from "@client/lib/schemas";
+import { useCreateApplicationMutation, useGetAuthUserQuery } from "@client/state/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import React from "react";
 import { useForm } from "react-hook-form";

--- a/client/src/app/(nondashboard)/search/[id]/ContactWidget.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/ContactWidget.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@/components/ui/button";
-import { useGetAuthUserQuery } from "@/state/api";
+import { Button } from "@client/components/ui/button";
+import { useGetAuthUserQuery } from "@client/state/api";
 import { Phone } from "lucide-react";
 import { useRouter } from "next/navigation";
 import React from "react";

--- a/client/src/app/(nondashboard)/search/[id]/PropertyDetails.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyDetails.tsx
@@ -1,7 +1,7 @@
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { AmenityIcons, HighlightIcons } from "@/lib/constants";
-import { formatEnumString } from "@/lib/utils";
-import { useGetPropertyQuery } from "@/state/api";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@client/components/ui/tabs";
+import { AmenityIcons, HighlightIcons } from "@client/lib/constants";
+import { formatEnumString } from "@client/lib/utils";
+import { useGetPropertyQuery } from "@client/state/api";
 import { HelpCircle } from "lucide-react";
 import React from "react";
 

--- a/client/src/app/(nondashboard)/search/[id]/PropertyLocation.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyLocation.tsx
@@ -1,4 +1,4 @@
-import { useGetPropertyQuery } from "@/state/api";
+import { useGetPropertyQuery } from "@client/state/api";
 import { Compass, MapPin } from "lucide-react";
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";

--- a/client/src/app/(nondashboard)/search/[id]/PropertyOverview.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyOverview.tsx
@@ -1,4 +1,4 @@
-import { useGetPropertyQuery } from "@/state/api";
+import { useGetPropertyQuery } from "@client/state/api";
 import { MapPin, Star } from "lucide-react";
 import React from "react";
 

--- a/client/src/app/(nondashboard)/search/[id]/page.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useGetAuthUserQuery } from "@/state/api";
+import { useGetAuthUserQuery } from "@client/state/api";
 import { useParams } from "next/navigation";
 import React, { useState } from "react";
-import ImagePreviews from "./ImagePreviews";
-import PropertyOverview from "./PropertyOverview";
-import PropertyDetails from "./PropertyDetails";
-import PropertyLocation from "./PropertyLocation";
-import ContactWidget from "./ContactWidget";
-import ApplicationModal from "./ApplicationModal";
+import ImagePreviews from "@client/app/(nondashboard)/search/[id]/ImagePreviews";
+import PropertyOverview from "@client/app/(nondashboard)/search/[id]/PropertyOverview";
+import PropertyDetails from "@client/app/(nondashboard)/search/[id]/PropertyDetails";
+import PropertyLocation from "@client/app/(nondashboard)/search/[id]/PropertyLocation";
+import ContactWidget from "@client/app/(nondashboard)/search/[id]/ContactWidget";
+import ApplicationModal from "@client/app/(nondashboard)/search/[id]/ApplicationModal";
 
 const SingleListing = () => {
   const { id } = useParams();

--- a/client/src/app/(nondashboard)/search/page.tsx
+++ b/client/src/app/(nondashboard)/search/page.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { NAVBAR_HEIGHT } from "@/lib/constants";
-import { useAppDispatch, useAppSelector } from "@/state/redux";
+import { NAVBAR_HEIGHT } from "@client/lib/constants";
+import { useAppDispatch, useAppSelector } from "@client/state/redux";
 import { useSearchParams } from "next/navigation";
 import React, { useEffect } from "react";
-import FiltersBar from "./FiltersBar";
-import FiltersFull from "./FiltersFull";
-import { cleanParams } from "@/lib/utils";
-import { setFilters } from "@/state";
-import Map from "./Map";
-import Listings from "./Listings";
+import FiltersBar from "@client/app/(nondashboard)/search/FiltersBar";
+import FiltersFull from "@client/app/(nondashboard)/search/FiltersFull";
+import { cleanParams } from "@client/lib/utils";
+import { setFilters } from "@client/state";
+import Map from "@client/app/(nondashboard)/search/Map";
+import Listings from "@client/app/(nondashboard)/search/Listings";
 
 const SearchPage = () => {
   const searchParams = useSearchParams();

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Providers from "./providers";
-import { Toaster } from "@/components/ui/sonner";
+import Providers from "@client/app/providers";
+import { Toaster } from "@client/components/ui/sonner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -1,5 +1,5 @@
-import Navbar from "@/components/Navbar";
-import Landing from "./(nondashboard)/landing/page";
+import Navbar from "@client/components/Navbar";
+import Landing from "@client/app/(nondashboard)/landing/page";
 
 export default function Home() {
   return (

--- a/client/src/app/providers.tsx
+++ b/client/src/app/providers.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import StoreProvider from "@/state/redux";
+import StoreProvider from "@client/state/redux";
 import { Authenticator } from "@aws-amplify/ui-react";
-import Auth from "./(auth)/authProvider";
+import Auth from "@client/app/(auth)/authProvider";
 
 const Providers = ({ children }: { children: React.ReactNode }) => {
   return (

--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -8,7 +8,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   useSidebar,
-} from "./ui/sidebar";
+} from "@client/components/ui/sidebar";
 import {
   Building,
   FileText,
@@ -18,8 +18,8 @@ import {
   Settings,
   X,
 } from "lucide-react";
-import { NAVBAR_HEIGHT } from "@/lib/constants";
-import { cn } from "@/lib/utils";
+import { NAVBAR_HEIGHT } from "@client/lib/constants";
+import { cn } from "@client/lib/utils";
 import Link from "next/link";
 
 const AppSidebar = ({ userType }: AppSidebarProps) => {

--- a/client/src/components/FormField.tsx
+++ b/client/src/components/FormField.tsx
@@ -11,18 +11,18 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
+} from "@client/components/ui/form";
+import { Input } from "@client/components/ui/input";
+import { Button } from "@client/components/ui/button";
+import { Textarea } from "@client/components/ui/textarea";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
+} from "@client/components/ui/select";
+import { Switch } from "@client/components/ui/switch";
 import { Edit, X, Plus } from "lucide-react";
 import { registerPlugin } from "filepond";
 import { FilePond } from "react-filepond";

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { NAVBAR_HEIGHT } from "@/lib/constants";
+import { NAVBAR_HEIGHT } from "@client/lib/constants";
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
-import { Button } from "./ui/button";
-import { useGetAuthUserQuery } from "@/state/api";
+import { Button } from "@client/components/ui/button";
+import { useGetAuthUserQuery } from "@client/state/api";
 import { usePathname, useRouter } from "next/navigation";
 import { signOut } from "aws-amplify/auth";
 import { Bell, MessageCircle, Plus, Search } from "lucide-react";
@@ -15,9 +15,9 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "./ui/dropdown-menu";
-import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
-import { SidebarTrigger } from "./ui/sidebar";
+} from "@client/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@client/components/ui/avatar";
+import { SidebarTrigger } from "@client/components/ui/sidebar";
 
 const Navbar = () => {
   const { data: authUser } = useGetAuthUserQuery();

--- a/client/src/components/SettingsForm.tsx
+++ b/client/src/components/SettingsForm.tsx
@@ -1,10 +1,10 @@
-import { SettingsFormData, settingsSchema } from "@/lib/schemas";
+import { SettingsFormData, settingsSchema } from "@client/lib/schemas";
 import { zodResolver } from "@hookform/resolvers/zod";
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
-import { Form } from "./ui/form";
-import { CustomFormField } from "./FormField";
-import { Button } from "./ui/button";
+import { Form } from "@client/components/ui/form";
+import { CustomFormField } from "@client/components/FormField";
+import { Button } from "@client/components/ui/button";
 
 const SettingsForm = ({
   initialData,

--- a/client/src/components/ui/avatar.tsx
+++ b/client/src/components/ui/avatar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,

--- a/client/src/components/ui/badge.tsx
+++ b/client/src/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/client/src/components/ui/checkbox.tsx
+++ b/client/src/components/ui/checkbox.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { Check } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,

--- a/client/src/components/ui/command.tsx
+++ b/client/src/components/ui/command.tsx
@@ -5,8 +5,8 @@ import { type DialogProps } from "@radix-ui/react-dialog"
 import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"
 
-import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { cn } from "@client/lib/utils"
+import { Dialog, DialogContent } from "@client/components/ui/dialog"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const Dialog = DialogPrimitive.Root
 

--- a/client/src/components/ui/dropdown-menu.tsx
+++ b/client/src/components/ui/dropdown-menu.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 

--- a/client/src/components/ui/form.tsx
+++ b/client/src/components/ui/form.tsx
@@ -12,8 +12,8 @@ import {
   useFormContext,
 } from "react-hook-form"
 
-import { cn } from "@/lib/utils"
-import { Label } from "@/components/ui/label"
+import { cn } from "@client/lib/utils"
+import { Label } from "@client/components/ui/label"
 
 const Form = FormProvider
 

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {

--- a/client/src/components/ui/label.tsx
+++ b/client/src/components/ui/label.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"

--- a/client/src/components/ui/navigation-menu.tsx
+++ b/client/src/components/ui/navigation-menu.tsx
@@ -3,7 +3,7 @@ import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
 import { cva } from "class-variance-authority"
 import { ChevronDown } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const NavigationMenu = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Root>,

--- a/client/src/components/ui/radio-group.tsx
+++ b/client/src/components/ui/radio-group.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
 import { Circle } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const RadioGroup = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,

--- a/client/src/components/ui/select.tsx
+++ b/client/src/components/ui/select.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const Select = SelectPrimitive.Root
 

--- a/client/src/components/ui/separator.tsx
+++ b/client/src/components/ui/separator.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as SeparatorPrimitive from "@radix-ui/react-separator"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,

--- a/client/src/components/ui/sheet.tsx
+++ b/client/src/components/ui/sheet.tsx
@@ -5,7 +5,7 @@ import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"
 import { X } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const Sheet = SheetPrimitive.Root
 

--- a/client/src/components/ui/sidebar.tsx
+++ b/client/src/components/ui/sidebar.tsx
@@ -5,19 +5,19 @@ import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
-import { useIsMobile } from "@/hooks/use-mobile"
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Separator } from "@/components/ui/separator"
-import { Sheet, SheetContent } from "@/components/ui/sheet"
-import { Skeleton } from "@/components/ui/skeleton"
+import { useIsMobile } from "@client/hooks/use-mobile"
+import { cn } from "@client/lib/utils"
+import { Button } from "@client/components/ui/button"
+import { Input } from "@client/components/ui/input"
+import { Separator } from "@client/components/ui/separator"
+import { Sheet, SheetContent } from "@client/components/ui/sheet"
+import { Skeleton } from "@client/components/ui/skeleton"
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@/components/ui/tooltip"
+} from "@client/components/ui/tooltip"
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7

--- a/client/src/components/ui/skeleton.tsx
+++ b/client/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 function Skeleton({
   className,

--- a/client/src/components/ui/slider.tsx
+++ b/client/src/components/ui/slider.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 
-import { cn } from "@/lib/utils";
+import { cn } from "@client/lib/utils";
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,

--- a/client/src/components/ui/switch.tsx
+++ b/client/src/components/ui/switch.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as SwitchPrimitives from "@radix-ui/react-switch";
 
-import { cn } from "@/lib/utils";
+import { cn } from "@client/lib/utils";
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,

--- a/client/src/components/ui/table.tsx
+++ b/client/src/components/ui/table.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const Table = React.forwardRef<
   HTMLTableElement,

--- a/client/src/components/ui/tabs.tsx
+++ b/client/src/components/ui/tabs.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const Tabs = TabsPrimitive.Root
 

--- a/client/src/components/ui/textarea.tsx
+++ b/client/src/components/ui/textarea.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const Textarea = React.forwardRef<
   HTMLTextAreaElement,

--- a/client/src/components/ui/tooltip.tsx
+++ b/client/src/components/ui/tooltip.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@client/lib/utils"
 
 const TooltipProvider = TooltipPrimitive.Provider
 

--- a/client/src/lib/schemas.ts
+++ b/client/src/lib/schemas.ts
@@ -1,5 +1,5 @@
 import * as z from "zod";
-import { PropertyTypeEnum } from "@/lib/constants";
+import { PropertyTypeEnum } from "@client/lib/constants";
 
 export const propertySchema = z.object({
   name: z.string().min(1, "Name is required"),

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -1,4 +1,4 @@
-import { cleanParams, createNewUserInDatabase, withToast } from "@/lib/utils";
+import { cleanParams, createNewUserInDatabase, withToast } from "@client/lib/utils";
 import {
   Application,
   Lease,
@@ -6,7 +6,7 @@ import {
   Payment,
   Property,
   Tenant,
-} from "@/types/prismaTypes";
+} from "@client/types/prismaTypes";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { fetchAuthSession, getCurrentUser } from "aws-amplify/auth";
 import { FiltersState } from ".";

--- a/client/src/state/redux.tsx
+++ b/client/src/state/redux.tsx
@@ -5,8 +5,8 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { setupListeners } from "@reduxjs/toolkit/query";
-import globalReducer from "@/state";
-import { api } from "@/state/api";
+import globalReducer from "@client/state";
+import { api } from "@client/state/api";
 
 /* REDUX STORE */
 const rootReducer = combineReducers({

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -1,6 +1,6 @@
 import { LucideIcon } from "lucide-react";
 import { AuthUser } from "aws-amplify/auth";
-import { Manager, Tenant, Property, Application } from "./prismaTypes";
+import { Manager, Tenant, Property, Application } from "@client/types/prismaTypes";
 import { MotionProps as OriginalMotionProps } from "framer-motion";
 
 declare module "framer-motion" {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -17,8 +17,10 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@client/*": ["./src/*"],
+      "@server/*": ["../server/src/*"]
     },
     "typeRoots": ["./node_modules/@types", "./src/types"],
     "types": [],

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -38,6 +38,7 @@
         "rimraf": "^6.0.1",
         "shx": "^0.3.4",
         "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.7.3"
       }
     },
@@ -3304,6 +3305,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -4465,6 +4479,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
@@ -4584,6 +4608,21 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {

--- a/server/package.json
+++ b/server/package.json
@@ -4,9 +4,9 @@
   "main": "index.js",
   "scripts": {
     "build": "rimraf dist && npx tsc",
-    "start": "npm run build && node dist/index.js",
-    "dev": "npm run build && concurrently \"npx tsc -w\" \"nodemon --exec ts-node src/index.ts\"",
-    "seed": "ts-node prisma/seed.ts",
+    "start": "npm run build && node -r tsconfig-paths/register dist/index.js",
+    "dev": "npm run build && concurrently \"npx tsc -w\" \"nodemon --exec node -r ts-node/register -r tsconfig-paths/register src/index.ts\"",
+    "seed": "ts-node -r tsconfig-paths/register prisma/seed.ts",
     "prisma:generate": "prisma generate",
     "postprisma:generate": "shx cp -r node_modules/.prisma/client/index.d.ts ../client/src/types/prismaTypes.d.ts"
   },
@@ -44,6 +44,7 @@
     "rimraf": "^6.0.1",
     "shx": "^0.3.4",
     "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3"
   }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,13 +4,13 @@ import bodyParser from "body-parser";
 import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
-import { authMiddleware } from "./middleware/authMiddleware";
+import { authMiddleware } from "@server/middleware/authMiddleware";
 /* ROUTE IMPORT */
-import tenantRoutes from "./routes/tenantRoutes";
-import managerRoutes from "./routes/managerRoutes";
-import propertyRoutes from "./routes/propertyRoutes";
-import leaseRoutes from "./routes/leaseRoutes";
-import applicationRoutes from "./routes/applicationRoutes";
+import tenantRoutes from "@server/routes/tenantRoutes";
+import managerRoutes from "@server/routes/managerRoutes";
+import propertyRoutes from "@server/routes/propertyRoutes";
+import leaseRoutes from "@server/routes/leaseRoutes";
+import applicationRoutes from "@server/routes/applicationRoutes";
 
 /* CONFIGURATIONS */
 dotenv.config();

--- a/server/src/routes/applicationRoutes.ts
+++ b/server/src/routes/applicationRoutes.ts
@@ -1,10 +1,10 @@
 import express from "express";
-import { authMiddleware } from "../middleware/authMiddleware";
+import { authMiddleware } from "@server/middleware/authMiddleware";
 import {
   createApplication,
   listApplications,
   updateApplicationStatus,
-} from "../controllers/applicationControllers";
+} from "@server/controllers/applicationControllers";
 
 const router = express.Router();
 

--- a/server/src/routes/leaseRoutes.ts
+++ b/server/src/routes/leaseRoutes.ts
@@ -1,6 +1,6 @@
 import express from "express";
-import { authMiddleware } from "../middleware/authMiddleware";
-import { getLeasePayments, getLeases } from "../controllers/leaseControllers";
+import { authMiddleware } from "@server/middleware/authMiddleware";
+import { getLeasePayments, getLeases } from "@server/controllers/leaseControllers";
 
 const router = express.Router();
 

--- a/server/src/routes/managerRoutes.ts
+++ b/server/src/routes/managerRoutes.ts
@@ -4,7 +4,7 @@ import {
   createManager,
   updateManager,
   getManagerProperties,
-} from "../controllers/managerControllers";
+} from "@server/controllers/managerControllers";
 
 const router = express.Router();
 

--- a/server/src/routes/propertyRoutes.ts
+++ b/server/src/routes/propertyRoutes.ts
@@ -3,9 +3,9 @@ import {
   getProperties,
   getProperty,
   createProperty,
-} from "../controllers/propertyControllers";
+} from "@server/controllers/propertyControllers";
 import multer from "multer";
-import { authMiddleware } from "../middleware/authMiddleware";
+import { authMiddleware } from "@server/middleware/authMiddleware";
 
 const storage = multer.memoryStorage();
 const upload = multer({ storage: storage });

--- a/server/src/routes/tenantRoutes.ts
+++ b/server/src/routes/tenantRoutes.ts
@@ -6,7 +6,7 @@ import {
   getCurrentResidences,
   addFavoriteProperty,
   removeFavoriteProperty,
-} from "../controllers/tenantControllers";
+} from "@server/controllers/tenantControllers";
 
 const router = express.Router();
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -28,8 +28,11 @@
     "module": "nodenext" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "nodenext" /* Specify how TypeScript looks up a file from a given module specifier. */,
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    "baseUrl": ".",                                  /* Specify the base directory to resolve non-relative module names. */
+    "paths": {
+      "@server/*": ["./src/*"],
+      "@client/*": ["../client/src/*"]
+    },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */


### PR DESCRIPTION
## Summary
- add @client/* and @server/* TypeScript path aliases
- configure Next.js and Node builds to resolve aliases
- refactor imports to use new aliases

## Testing
- `npm --prefix server run build`
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a97d7791808328864ebd5705ccc29a