### PR TITLE
Add skeleton loaders for search and property detail views

### DIFF
--- a/client/src/app/(nondashboard)/search/Listings.tsx
+++ b/client/src/app/(nondashboard)/search/Listings.tsx
@@ -10,6 +10,7 @@ import { Property } from "@/types/prismaTypes";
 import Card from "@/components/Card";
 import React from "react";
 import CardCompact from "@/components/CardCompact";
+import ListingsSkeleton from "./ListingsSkeleton";
 
 const Listings = () => {
   const { data: authUser } = useGetAuthUserQuery();
@@ -50,7 +51,7 @@ const Listings = () => {
     }
   };
 
-  if (isLoading) return <>Loading...</>;
+  if (isLoading) return <ListingsSkeleton />;
   if (isError || !properties) return <div>Failed to fetch properties</div>;
 
   return (

--- a/client/src/app/(nondashboard)/search/ListingsSkeleton.tsx
+++ b/client/src/app/(nondashboard)/search/ListingsSkeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ListingsSkeleton() {
+  return (
+    <div className="w-full p-4 space-y-5">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="bg-card rounded-xl shadow-lg">
+          <Skeleton className="h-48 w-full rounded-t-xl" />
+          <div className="p-4 space-y-2">
+            <Skeleton className="h-6 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <div className="flex justify-between pt-2">
+              <Skeleton className="h-4 w-1/4" />
+              <Skeleton className="h-4 w-1/4" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/app/(nondashboard)/search/SearchSkeleton.tsx
+++ b/client/src/app/(nondashboard)/search/SearchSkeleton.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import ListingsSkeleton from "./ListingsSkeleton";
+
+export default function SearchSkeleton() {
+  return (
+    <div className="w-full mx-auto px-5 flex flex-col">
+      <Skeleton className="h-12 w-full mb-4" />
+      <div className="flex justify-between flex-1 overflow-hidden gap-3 mb-5">
+        <Skeleton className="h-full w-3/12" />
+        <Skeleton className="h-full flex-1" />
+        <div className="basis-4/12 overflow-y-auto">
+          <ListingsSkeleton />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/app/(nondashboard)/search/[id]/PropertyDetailSkeleton.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyDetailSkeleton.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import PropertyOverviewSkeleton from "./PropertyOverviewSkeleton";
+import PropertyDetailsSkeleton from "./PropertyDetailsSkeleton";
+import PropertyLocationSkeleton from "./PropertyLocationSkeleton";
+
+export default function PropertyDetailSkeleton() {
+  return (
+    <div>
+      <Skeleton className="h-64 w-full" />
+      <div className="flex flex-col md:flex-row justify-center gap-10 mx-10 md:w-2/3 md:mx-auto mt-16 mb-8">
+        <div className="order-2 md:order-1 space-y-6">
+          <PropertyOverviewSkeleton />
+          <PropertyDetailsSkeleton />
+          <PropertyLocationSkeleton />
+        </div>
+        <div className="order-1 md:order-2">
+          <Skeleton className="h-64 w-80 rounded-xl" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/app/(nondashboard)/search/[id]/PropertyDetails.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyDetails.tsx
@@ -4,6 +4,7 @@ import { formatEnumString } from "@/lib/utils";
 import { useGetPropertyQuery } from "@/state/api";
 import { HelpCircle } from "lucide-react";
 import React from "react";
+import PropertyDetailsSkeleton from "./PropertyDetailsSkeleton";
 
 const PropertyDetails = ({ propertyId }: PropertyDetailsProps) => {
   const {
@@ -12,7 +13,7 @@ const PropertyDetails = ({ propertyId }: PropertyDetailsProps) => {
     isLoading,
   } = useGetPropertyQuery(propertyId);
 
-  if (isLoading) return <>Loading...</>;
+  if (isLoading) return <PropertyDetailsSkeleton />;
   if (isError || !property) {
     return <>Property not Found</>;
   }

--- a/client/src/app/(nondashboard)/search/[id]/PropertyDetailsSkeleton.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyDetailsSkeleton.tsx
@@ -1,0 +1,32 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function PropertyDetailsSkeleton() {
+  return (
+    <div className="mb-6 space-y-10">
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-1/3" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-xl" />
+          ))}
+        </div>
+      </div>
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-1/3" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-xl" />
+          ))}
+        </div>
+      </div>
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-1/3" />
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-4 w-2/3" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/app/(nondashboard)/search/[id]/PropertyLocation.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyLocation.tsx
@@ -3,6 +3,7 @@ import { Compass, MapPin } from "lucide-react";
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import React, { useEffect, useRef } from "react";
+import PropertyLocationSkeleton from "./PropertyLocationSkeleton";
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
 
@@ -41,7 +42,7 @@ const PropertyLocation = ({ propertyId }: PropertyDetailsProps) => {
     return () => map.remove();
   }, [property, isError, isLoading]);
 
-  if (isLoading) return <>Loading...</>;
+  if (isLoading) return <PropertyLocationSkeleton />;
   if (isError || !property) {
     return <>Property not Found</>;
   }

--- a/client/src/app/(nondashboard)/search/[id]/PropertyLocationSkeleton.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyLocationSkeleton.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function PropertyLocationSkeleton() {
+  return (
+    <div className="py-16 space-y-4">
+      <Skeleton className="h-6 w-1/3" />
+      <Skeleton className="h-4 w-2/3" />
+      <Skeleton className="h-[300px] w-full rounded-lg" />
+    </div>
+  );
+}

--- a/client/src/app/(nondashboard)/search/[id]/PropertyOverview.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyOverview.tsx
@@ -1,6 +1,7 @@
 import { useGetPropertyQuery } from "@/state/api";
 import { MapPin, Star } from "lucide-react";
 import React from "react";
+import PropertyOverviewSkeleton from "./PropertyOverviewSkeleton";
 
 const PropertyOverview = ({ propertyId }: PropertyOverviewProps) => {
   const {
@@ -9,7 +10,7 @@ const PropertyOverview = ({ propertyId }: PropertyOverviewProps) => {
     isLoading,
   } = useGetPropertyQuery(propertyId);
 
-  if (isLoading) return <>Loading...</>;
+  if (isLoading) return <PropertyOverviewSkeleton />;
   if (isError || !property) {
     return <>Property not Found</>;
   }

--- a/client/src/app/(nondashboard)/search/[id]/PropertyOverviewSkeleton.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyOverviewSkeleton.tsx
@@ -1,0 +1,29 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function PropertyOverviewSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-1/3" />
+        <Skeleton className="h-8 w-2/3" />
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+      <div className="border border-border rounded-xl p-6">
+        <div className="flex justify-between gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-6 w-3/4" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-1/2" />
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-4 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/app/(nondashboard)/search/[id]/loading.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import PropertyDetailSkeleton from "./PropertyDetailSkeleton";
+
+export default function Loading() {
+  return <PropertyDetailSkeleton />;
+}

--- a/client/src/app/(nondashboard)/search/loading.tsx
+++ b/client/src/app/(nondashboard)/search/loading.tsx
@@ -1,0 +1,5 @@
+import SearchSkeleton from "./SearchSkeleton";
+
+export default function Loading() {
+  return <SearchSkeleton />;
+}


### PR DESCRIPTION
## Summary
- add ListingsSkeleton and SearchSkeleton components and route-level loading for search
- implement PropertyDetailSkeleton with section skeletons and loading handlers
- replace text loaders with styled skeletons using design tokens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a97d78aa28832882f61999913c94d8