### PR TITLE
Configure Amplify for SSR with Cognito cookie storage

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -29,6 +29,19 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
+## Cognito Configuration
+
+The app expects the following environment variables to configure AWS Cognito and Amplify:
+
+```bash
+NEXT_PUBLIC_AWS_COGNITO_REGION=<cognito-region>
+NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID=<user-pool-id>
+NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID=<app-client-id>
+NEXT_PUBLIC_AWS_COGNITO_COOKIE_DOMAIN=<cookie-domain>
+```
+
+These variables are used in `pages/_app.tsx` to initialize Amplify and to store authentication tokens in cookies for SSR.
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/client/src/app/(auth)/authProvider.tsx
+++ b/client/src/app/(auth)/authProvider.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useEffect } from "react";
-import { Amplify } from "aws-amplify";
 import {
   Authenticator,
   Heading,
@@ -13,16 +12,7 @@ import {
 import "@aws-amplify/ui-react/styles.css";
 import { useRouter, usePathname } from "next/navigation";
 
-// https://docs.amplify.aws/gen1/javascript/tools/libraries/configure-categories/
-Amplify.configure({
-  Auth: {
-    Cognito: {
-      userPoolId: process.env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID!,
-      userPoolClientId:
-        process.env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID!,
-    },
-  },
-});
+// Amplify is configured globally in `pages/_app.tsx`.
 
 const components = {
   Header() {
@@ -142,7 +132,7 @@ const formFields = {
 const Auth = ({ children }: { children: React.ReactNode }) => {
   const { user } = useAuthenticator((context) => [context.user]);
   const router = useRouter();
-  const pathname = usePathname();
+  const pathname = usePathname() ?? "";
 
   const isAuthPage = pathname.match(/^\/(signin|signup)$/);
   const isDashboardPage =

--- a/client/src/app/(dashboard)/layout.tsx
+++ b/client/src/app/(dashboard)/layout.tsx
@@ -11,7 +11,7 @@ import { usePathname, useRouter } from "next/navigation";
 const DashboardLayout = ({ children }: { children: React.ReactNode }) => {
   const { data: authUser, isLoading: authLoading } = useGetAuthUserQuery();
   const router = useRouter();
-  const pathname = usePathname();
+  const pathname = usePathname() ?? "";
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -1,0 +1,53 @@
+import App, { AppContext, AppProps } from "next/app";
+import { Amplify } from "aws-amplify";
+import { CookieStorage } from "aws-amplify/utils";
+import { runWithAmplifyServerContext } from "aws-amplify/adapter-core";
+import { fetchAuthSession } from "aws-amplify/auth/server";
+
+Amplify.configure(
+  {
+    Auth: {
+      Cognito: {
+        userPoolId: process.env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_ID!,
+        userPoolClientId: process.env.NEXT_PUBLIC_AWS_COGNITO_USER_POOL_CLIENT_ID!,
+        region: process.env.NEXT_PUBLIC_AWS_COGNITO_REGION!,
+      },
+      storage: new CookieStorage({
+        domain: process.env.NEXT_PUBLIC_AWS_COGNITO_COOKIE_DOMAIN,
+        path: "/",
+        expires: 365,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+      }),
+    },
+  },
+  { ssr: true }
+);
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+
+MyApp.getInitialProps = async (appContext: AppContext) => {
+  const appProps = await App.getInitialProps(appContext);
+
+  const tokens = await runWithAmplifyServerContext(
+    Amplify.getConfig(),
+    Amplify.libraryOptions,
+    async (contextSpec) => {
+      try {
+        const session = await fetchAuthSession(contextSpec);
+        return session.tokens ?? null;
+      } catch {
+        return null;
+      }
+    }
+  );
+
+  return {
+    ...appProps,
+    pageProps: { ...appProps.pageProps, tokens },
+  };
+};
+
+export default MyApp;


### PR DESCRIPTION
## Summary
- Configure AWS Amplify in `pages/_app.tsx` with Cognito settings and cookie-based auth storage
- Move Amplify setup out of `authProvider` and handle nullable paths
- Document Cognito environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Property 'id' does not exist on type 'Record<string, string | string[]> | null')*


------
https://chatgpt.com/codex/tasks/task_e_68a97d7a0a28832883b0c031858be2ee