### PR TITLE
feat: guard manager and tenant endpoints by role

### DIFF
--- a/server/src/routes/managerRoutes.ts
+++ b/server/src/routes/managerRoutes.ts
@@ -5,12 +5,17 @@ import {
   updateManager,
   getManagerProperties,
 } from "../controllers/managerControllers";
+import { authMiddleware } from "../middleware/authMiddleware";
 
 const router = express.Router();
 
-router.get("/:cognitoId", getManager);
-router.put("/:cognitoId", updateManager);
-router.get("/:cognitoId/properties", getManagerProperties);
-router.post("/", createManager);
+router.get("/:cognitoId", authMiddleware(["manager"]), getManager);
+router.put("/:cognitoId", authMiddleware(["manager"]), updateManager);
+router.get(
+  "/:cognitoId/properties",
+  authMiddleware(["manager"]),
+  getManagerProperties
+);
+router.post("/", authMiddleware(["manager"]), createManager);
 
 export default router;

--- a/server/src/routes/tenantRoutes.ts
+++ b/server/src/routes/tenantRoutes.ts
@@ -7,14 +7,27 @@ import {
   addFavoriteProperty,
   removeFavoriteProperty,
 } from "../controllers/tenantControllers";
+import { authMiddleware } from "../middleware/authMiddleware";
 
 const router = express.Router();
 
-router.get("/:cognitoId", getTenant);
-router.put("/:cognitoId", updateTenant);
-router.post("/", createTenant);
-router.get("/:cognitoId/current-residences", getCurrentResidences);
-router.post("/:cognitoId/favorites/:propertyId", addFavoriteProperty);
-router.delete("/:cognitoId/favorites/:propertyId", removeFavoriteProperty);
+router.get("/:cognitoId", authMiddleware(["tenant"]), getTenant);
+router.put("/:cognitoId", authMiddleware(["tenant"]), updateTenant);
+router.post("/", authMiddleware(["tenant"]), createTenant);
+router.get(
+  "/:cognitoId/current-residences",
+  authMiddleware(["tenant"]),
+  getCurrentResidences
+);
+router.post(
+  "/:cognitoId/favorites/:propertyId",
+  authMiddleware(["tenant"]),
+  addFavoriteProperty
+);
+router.delete(
+  "/:cognitoId/favorites/:propertyId",
+  authMiddleware(["tenant"]),
+  removeFavoriteProperty
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- parse roles from JWT claims
- protect tenant and manager routes using role-based auth middleware

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a97d7ba8208328beccfea9b9711047