### PR TITLE
Add Prisma seed script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Real Estate Project
+
+## Database Seeding
+
+The backend uses Prisma for data access. To populate a development database with representative data run the seed script from the `server` directory:
+
+```bash
+cd server
+npm install
+npm run seed
+```
+
+The script creates sample managers and tenants (user roles), properties with geolocation coordinates, and applications linking tenants to properties. Ensure the `DATABASE_URL` environment variable points to a PostgreSQL database with PostGIS enabled before running the command.


### PR DESCRIPTION
## Summary
- implement Prisma seed script generating sample managers, tenants, properties with geolocation, and applications
- document database seed usage in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run seed` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a97d80688c832890b18b7f1ffd9d83