### PR TITLE
Add Terraform infrastructure modules and state management

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:356j/3XnXEKr9nyicLUufzoF4Yr6hRy481KIxRVpK0c=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,26 @@
+# Infrastructure
+
+Terraform configuration for core AWS resources powering the Real Estate application.
+
+## Terraform State
+
+Terraform state is stored in an S3 bucket with DynamoDB table for locking. Ensure the bucket `real-estate-terraform-state` and DynamoDB table `real-estate-terraform-locks` exist and have versioning enabled before running the configuration.
+
+## Deployment
+
+1. Install [Terraform](https://www.terraform.io/) version 1.3 or newer.
+2. Configure AWS credentials with permission to create the resources.
+3. Initialize the project:
+   ```sh
+   terraform init
+   ```
+4. Review the execution plan:
+   ```sh
+   terraform plan
+   ```
+5. Apply the changes:
+   ```sh
+   terraform apply
+   ```
+
+The modules provision a VPC, ECS cluster, S3 bucket, and RDS instance. Key identifiers and secrets are written to AWS Systems Manager Parameter Store under the `/real-estate/` path for consumption by other services.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,66 @@
+module "vpc" {
+  source         = "./modules/vpc"
+  cidr_block     = var.vpc_cidr_block
+  public_subnets = var.public_subnets
+  tags           = var.tags
+}
+
+module "s3" {
+  source      = "./modules/s3"
+  bucket_name = var.bucket_name
+  tags        = var.tags
+}
+
+module "rds" {
+  source                 = "./modules/rds"
+  db_name                = var.db_name
+  username               = var.db_username
+  instance_class         = var.db_instance_class
+  allocated_storage      = var.db_allocated_storage
+  subnet_ids             = module.vpc.public_subnet_ids
+  vpc_security_group_ids = []
+  tags                   = var.tags
+}
+
+module "ecs" {
+  source = "./modules/ecs"
+  name   = var.cluster_name
+  tags   = var.tags
+}
+
+# Store important identifiers and secrets in SSM Parameter Store
+resource "aws_ssm_parameter" "vpc_id" {
+  name  = "/real-estate/vpc/id"
+  type  = "String"
+  value = module.vpc.vpc_id
+}
+
+resource "aws_ssm_parameter" "public_subnets" {
+  name  = "/real-estate/vpc/public_subnets"
+  type  = "String"
+  value = join(",", module.vpc.public_subnet_ids)
+}
+
+resource "aws_ssm_parameter" "assets_bucket" {
+  name  = "/real-estate/s3/assets_bucket"
+  type  = "String"
+  value = module.s3.bucket_name
+}
+
+resource "aws_ssm_parameter" "rds_endpoint" {
+  name  = "/real-estate/rds/endpoint"
+  type  = "String"
+  value = module.rds.db_endpoint
+}
+
+resource "aws_ssm_parameter" "rds_password" {
+  name  = "/real-estate/rds/password"
+  type  = "SecureString"
+  value = module.rds.db_password
+}
+
+resource "aws_ssm_parameter" "ecs_cluster" {
+  name  = "/real-estate/ecs/cluster_arn"
+  type  = "String"
+  value = module.ecs.cluster_arn
+}

--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -1,0 +1,4 @@
+resource "aws_ecs_cluster" "this" {
+  name = var.name
+  tags = var.tags
+}

--- a/infra/modules/ecs/outputs.tf
+++ b/infra/modules/ecs/outputs.tf
@@ -1,0 +1,4 @@
+output "cluster_arn" {
+  description = "ARN of the ECS cluster"
+  value       = aws_ecs_cluster.this.arn
+}

--- a/infra/modules/ecs/variables.tf
+++ b/infra/modules/ecs/variables.tf
@@ -1,0 +1,10 @@
+variable "name" {
+  description = "Name of the ECS cluster."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to the ECS cluster."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -1,0 +1,23 @@
+resource "random_password" "db" {
+  length  = 16
+  special = true
+}
+
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.db_name}-subnet-group"
+  subnet_ids = var.subnet_ids
+  tags       = var.tags
+}
+
+resource "aws_db_instance" "this" {
+  identifier             = var.db_name
+  engine                 = "postgres"
+  instance_class         = var.instance_class
+  allocated_storage      = var.allocated_storage
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  username               = var.username
+  password               = random_password.db.result
+  skip_final_snapshot    = true
+  vpc_security_group_ids = var.vpc_security_group_ids
+  tags                   = var.tags
+}

--- a/infra/modules/rds/outputs.tf
+++ b/infra/modules/rds/outputs.tf
@@ -1,0 +1,10 @@
+output "db_endpoint" {
+  description = "Endpoint of the RDS instance"
+  value       = aws_db_instance.this.endpoint
+}
+
+output "db_password" {
+  description = "Generated database password"
+  value       = random_password.db.result
+  sensitive   = true
+}

--- a/infra/modules/rds/variables.tf
+++ b/infra/modules/rds/variables.tf
@@ -1,0 +1,36 @@
+variable "db_name" {
+  description = "Name of the database."
+  type        = string
+}
+
+variable "username" {
+  description = "Master username for the database."
+  type        = string
+}
+
+variable "instance_class" {
+  description = "RDS instance class."
+  type        = string
+}
+
+variable "allocated_storage" {
+  description = "Allocated storage in GB."
+  type        = number
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs for the DB subnet group."
+  type        = list(string)
+}
+
+variable "vpc_security_group_ids" {
+  description = "Security group IDs to associate with the RDS instance."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags to apply to resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -1,0 +1,11 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+  tags   = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "versioning" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/infra/modules/s3/outputs.tf
+++ b/infra/modules/s3/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "Name of the bucket"
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the bucket"
+  value       = aws_s3_bucket.this.arn
+}

--- a/infra/modules/s3/variables.tf
+++ b/infra/modules/s3/variables.tf
@@ -1,0 +1,10 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to the bucket."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/vpc/main.tf
+++ b/infra/modules/vpc/main.tf
@@ -1,0 +1,16 @@
+resource "aws_vpc" "this" {
+  cidr_block = var.cidr_block
+  tags       = merge({ Name = "real-estate-vpc" }, var.tags)
+}
+
+locals {
+  subnet_map = { for idx, cidr in var.public_subnets : idx => cidr }
+}
+
+resource "aws_subnet" "public" {
+  for_each                = local.subnet_map
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = each.value
+  map_public_ip_on_launch = true
+  tags                    = merge({ Name = "public-${each.key}" }, var.tags)
+}

--- a/infra/modules/vpc/outputs.tf
+++ b/infra/modules/vpc/outputs.tf
@@ -1,0 +1,9 @@
+output "vpc_id" {
+  description = "ID of the created VPC"
+  value       = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the created public subnets"
+  value       = [for s in aws_subnet.public : s.id]
+}

--- a/infra/modules/vpc/variables.tf
+++ b/infra/modules/vpc/variables.tf
@@ -1,0 +1,15 @@
+variable "cidr_block" {
+  description = "CIDR block for the VPC."
+  type        = string
+}
+
+variable "public_subnets" {
+  description = "List of public subnet CIDR blocks."
+  type        = list(string)
+}
+
+variable "tags" {
+  description = "Tags to apply to the VPC resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,24 @@
+output "vpc_id" {
+  description = "ID of the created VPC"
+  value       = module.vpc.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = module.vpc.public_subnet_ids
+}
+
+output "assets_bucket_name" {
+  description = "Name of the S3 assets bucket"
+  value       = module.s3.bucket_name
+}
+
+output "db_endpoint" {
+  description = "Endpoint of the RDS instance"
+  value       = module.rds.db_endpoint
+}
+
+output "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster"
+  value       = module.ecs.cluster_arn
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,59 @@
+variable "region" {
+  description = "AWS region to deploy resources in."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "List of public subnet CIDR blocks."
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "bucket_name" {
+  description = "S3 bucket name for application assets."
+  type        = string
+  default     = "real-estate-assets"
+}
+
+variable "db_name" {
+  description = "Name of the RDS database."
+  type        = string
+  default     = "realestate"
+}
+
+variable "db_username" {
+  description = "Master username for the database."
+  type        = string
+  default     = "admin"
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class."
+  type        = string
+  default     = "db.t3.micro"
+}
+
+variable "db_allocated_storage" {
+  description = "Allocated storage for the database in GB."
+  type        = number
+  default     = 20
+}
+
+variable "cluster_name" {
+  description = "Name of the ECS cluster."
+  type        = string
+  default     = "real-estate-cluster"
+}
+
+variable "tags" {
+  description = "Common tags to apply to resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+  backend "s3" {
+    bucket         = "real-estate-terraform-state"
+    key            = "state/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "real-estate-terraform-locks"
+    encrypt        = true
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform modules for VPC, S3, RDS, and ECS resources
- push resource identifiers and secrets to AWS SSM Parameter Store
- document deployment and configure remote state in S3 with DynamoDB locks

## Testing
- `terraform init -backend=false`
- `terraform validate`
- `terraform fmt -check -recursive`

------
https://chatgpt.com/codex/tasks/task_e_68a97da34f6c8328bd844cf86132c41d