### PR TITLE
Add Playwright smoke tests and CI workflow

### DIFF
--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -1,0 +1,26 @@
+name: Playwright Smoke Tests
+
+on:
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: client/package-lock.json
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run test:smoke
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: client/playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,6 @@ server/dist/
 client/.env
 server/.env
 client/.next/
+client/playwright-report/
+client/test-results/
 node_modules

--- a/client/e2e/smoke.spec.ts
+++ b/client/e2e/smoke.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Smoke', () => {
+  test('landing page loads @smoke', async ({ page }) => {
+    await page.goto('/');
+    await expect(
+      page.getByRole('heading', {
+        name: /Start your journey to finding the perfect place to call home/i,
+      }),
+    ).toBeVisible();
+  });
+
+  test('search page loads @smoke', async ({ page }) => {
+    await page.route('**/properties**', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.goto('/search?location=New%20York&lat=40.73061&lng=-73.935242');
+    await expect(page).toHaveURL(/search/);
+  });
+});

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -55,6 +55,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.55.0",
         "@types/lodash": "^4.17.15",
         "@types/node": "^20.17.16",
         "@types/react": "^19",
@@ -2905,6 +2906,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -9210,6 +9227,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test",
+    "test:smoke": "playwright test --grep @smoke"
   },
   "dependencies": {
     "@aws-amplify/ui-react": "^6.9.1",
@@ -56,6 +58,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.55.0",
     "@types/lodash": "^4.17.15",
     "@types/node": "^20.17.16",
     "@types/react": "^19",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30 * 1000,
+  retries: 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:3000',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});


### PR DESCRIPTION
## Summary
- add Playwright smoke tests for landing and search pages
- configure Playwright to capture screenshots and videos on failure
- run smoke suite in GitHub Actions for every PR

## Testing
- `npx playwright test --grep @smoke`

------
https://chatgpt.com/codex/tasks/task_e_68a97da212f08328a309e4c172e3c527