### PR TITLE
Add backup infrastructure modules and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ client/.env
 server/.env
 client/.next/
 node_modules
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup

--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -1,0 +1,11 @@
+# Backup Strategy
+
+## RDS Snapshot Schedule
+- Automated snapshots run daily at **05:00 UTC** via AWS Backup.
+- Backups are retained for **30 days** in a dedicated backup vault.
+- The schedule and retention are configurable through Terraform variables.
+
+## S3 Versioning and Replication
+- S3 buckets have **versioning enabled** to preserve object history.
+- A cross-region replication rule copies objects to a bucket in another region for disaster recovery.
+- Replicated buckets also maintain versioning to provide multi-region recovery points.

--- a/docs/restore-runbooks.md
+++ b/docs/restore-runbooks.md
@@ -1,0 +1,13 @@
+# Restore Runbooks
+
+## Restoring an RDS Instance
+1. Open the **AWS Backup** console and locate the required snapshot in the backup vault.
+2. Start a restore job targeting a new RDS instance or cluster.
+3. Update application configuration to point to the restored endpoint.
+4. Validate data integrity before promoting the instance to production.
+
+## Restoring S3 Objects
+1. Identify the required object version in the source or replica bucket.
+2. Use the AWS Console or CLI to restore or copy that version to the desired key.
+3. If the primary region is unavailable, promote the replica bucket and update DNS or application configuration.
+4. Verify application access to restored objects.

--- a/infra/modules/rds_backup/.terraform.lock.hcl
+++ b/infra/modules/rds_backup/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/modules/rds_backup/main.tf
+++ b/infra/modules/rds_backup/main.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_backup_vault" "this" {
+  name = var.backup_vault_name
+}
+
+resource "aws_backup_plan" "this" {
+  name = "${var.backup_vault_name}-plan"
+
+  rule {
+    rule_name         = "rds-backup"
+    target_vault_name = aws_backup_vault.this.name
+    schedule          = var.schedule_expression
+
+    lifecycle {
+      delete_after = var.retention_days
+    }
+  }
+}
+
+resource "aws_iam_role" "backup" {
+  name = "${var.backup_vault_name}-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "backup.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+resource "aws_backup_selection" "this" {
+  name         = "${var.backup_vault_name}-selection"
+  iam_role_arn = aws_iam_role.backup.arn
+  plan_id      = aws_backup_plan.this.id
+  resources    = [var.db_resource_arn]
+}

--- a/infra/modules/rds_backup/outputs.tf
+++ b/infra/modules/rds_backup/outputs.tf
@@ -1,0 +1,4 @@
+output "backup_plan_id" {
+  description = "ID of the backup plan"
+  value       = aws_backup_plan.this.id
+}

--- a/infra/modules/rds_backup/variables.tf
+++ b/infra/modules/rds_backup/variables.tf
@@ -1,0 +1,22 @@
+variable "db_resource_arn" {
+  description = "ARN of the RDS database instance or cluster to back up"
+  type        = string
+}
+
+variable "backup_vault_name" {
+  description = "Name of the AWS Backup vault"
+  type        = string
+  default     = "rds-backup-vault"
+}
+
+variable "schedule_expression" {
+  description = "Cron expression for backup schedule"
+  type        = string
+  default     = "cron(0 5 * * ? *)" # Daily at 05:00 UTC
+}
+
+variable "retention_days" {
+  description = "Number of days to retain backups"
+  type        = number
+  default     = 30
+}

--- a/infra/modules/s3_replication/.terraform.lock.hcl
+++ b/infra/modules/s3_replication/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/modules/s3_replication/main.tf
+++ b/infra/modules/s3_replication/main.tf
@@ -1,0 +1,93 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "destination"
+  region = var.destination_region
+}
+
+resource "aws_s3_bucket" "source" {
+  bucket = var.source_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "source" {
+  bucket = aws_s3_bucket.source.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket" "destination" {
+  provider = aws.destination
+  bucket   = var.destination_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "destination" {
+  provider = aws.destination
+  bucket   = aws_s3_bucket.destination.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_iam_role" "replication" {
+  name = "${var.source_bucket_name}-replication-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Action = "sts:AssumeRole",
+      Effect = "Allow",
+      Principal = {
+        Service = "s3.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "replication" {
+  name = "${var.source_bucket_name}-replication-policy"
+  role = aws_iam_role.replication.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action   = ["s3:GetReplicationConfiguration", "s3:ListBucket"],
+        Effect   = "Allow",
+        Resource = [aws_s3_bucket.source.arn]
+      },
+      {
+        Action   = ["s3:GetObjectVersion", "s3:GetObjectVersionAcl"],
+        Effect   = "Allow",
+        Resource = ["${aws_s3_bucket.source.arn}/*"]
+      },
+      {
+        Action   = ["s3:ReplicateObject", "s3:ReplicateDelete"],
+        Effect   = "Allow",
+        Resource = ["${aws_s3_bucket.destination.arn}/*"]
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_replication_configuration" "this" {
+  bucket = aws_s3_bucket.source.id
+  role   = aws_iam_role.replication.arn
+
+  rule {
+    id     = "replication"
+    status = "Enabled"
+
+    destination {
+      bucket        = aws_s3_bucket.destination.arn
+      storage_class = "STANDARD"
+    }
+  }
+}

--- a/infra/modules/s3_replication/outputs.tf
+++ b/infra/modules/s3_replication/outputs.tf
@@ -1,0 +1,9 @@
+output "source_bucket_arn" {
+  description = "ARN of the source S3 bucket"
+  value       = aws_s3_bucket.source.arn
+}
+
+output "destination_bucket_arn" {
+  description = "ARN of the replicated S3 bucket"
+  value       = aws_s3_bucket.destination.arn
+}

--- a/infra/modules/s3_replication/variables.tf
+++ b/infra/modules/s3_replication/variables.tf
@@ -1,0 +1,14 @@
+variable "source_bucket_name" {
+  description = "Name of the primary S3 bucket"
+  type        = string
+}
+
+variable "destination_bucket_name" {
+  description = "Name of the replica S3 bucket"
+  type        = string
+}
+
+variable "destination_region" {
+  description = "AWS region for the replica bucket"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- document RDS backup schedule and S3 versioning strategy
- add Terraform modules for RDS backups and S3 cross-region replication
- provide restore runbooks for RDS and S3

## Testing
- `terraform -chdir=infra/modules/rds_backup init -backend=false`
- `terraform -chdir=infra/modules/rds_backup validate`
- `terraform -chdir=infra/modules/s3_replication init -backend=false`
- `terraform -chdir=infra/modules/s3_replication validate`


------
https://chatgpt.com/codex/tasks/task_e_68a97da016f48328806e001d288c4d74