### PR TITLE
Add request ID middleware with structured JSON logging

### DIFF
--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
+import { logInfo } from "../utils/logger";
 
 const prisma = new PrismaClient();
 
@@ -172,7 +173,7 @@ export const updateApplicationStatus = async (
   try {
     const { id } = req.params;
     const { status } = req.body;
-    console.log("status:", status);
+    logInfo(req, `status: ${status}`);
 
     const application = await prisma.application.findUnique({
       where: { id: Number(id) },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,8 @@ import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
 import { authMiddleware } from "./middleware/authMiddleware";
+import { requestIdMiddleware } from "./middleware/requestIdMiddleware";
+import { logInfo } from "./utils/logger";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenantRoutes";
 import managerRoutes from "./routes/managerRoutes";
@@ -18,14 +20,27 @@ const app = express();
 app.use(express.json());
 app.use(helmet());
 app.use(helmet.crossOriginResourcePolicy({ policy: "cross-origin" }));
-app.use(morgan("common"));
+app.use(requestIdMiddleware);
+morgan.token("requestId", (req) => (req as any).requestId);
+app.use(
+  morgan((tokens, req, res) =>
+    JSON.stringify({
+      level: "info",
+      requestId: tokens.requestId(req, res),
+      method: tokens.method(req, res),
+      url: tokens.url(req, res),
+      status: Number(tokens.status(req, res)),
+      responseTime: Number(tokens["response-time"](req, res)),
+    })
+  )
+);
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cors());
 
 /* ROUTES */
 app.get("/", (req, res) => {
-  res.send("This is home route");
+  res.json({ message: "This is home route" });
 });
 
 app.use("/applications", applicationRoutes);
@@ -37,5 +52,5 @@ app.use("/managers", authMiddleware(["manager"]), managerRoutes);
 /* SERVER */
 const port = Number(process.env.PORT) || 3002;
 app.listen(port, "0.0.0.0", () => {
-  console.log(`Server running on port ${port}`);
+  logInfo(null, `Server running on port ${port}`);
 });

--- a/server/src/middleware/authMiddleware.ts
+++ b/server/src/middleware/authMiddleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import jwt, { JwtPayload } from "jsonwebtoken";
+import { logError } from "../utils/logger";
 
 interface DecodedToken extends JwtPayload {
   sub: string;
@@ -40,7 +41,7 @@ export const authMiddleware = (allowedRoles: string[]) => {
         return;
       }
     } catch (err) {
-      console.error("Failed to decode token:", err);
+      logError(req, "Failed to decode token", { error: err });
       res.status(400).json({ message: "Invalid token" });
       return;
     }

--- a/server/src/middleware/requestIdMiddleware.ts
+++ b/server/src/middleware/requestIdMiddleware.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from "express";
+import { v4 as uuidv4 } from "uuid";
+
+declare global {
+  namespace Express {
+    interface Request {
+      requestId: string;
+    }
+  }
+}
+
+export const requestIdMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const requestId = uuidv4();
+  req.requestId = requestId;
+  res.setHeader("X-Request-Id", requestId);
+
+  const originalJson = res.json.bind(res);
+  res.json = (body: any) => {
+    if (body && typeof body === "object" && !body.requestId) {
+      body.requestId = requestId;
+    }
+    return originalJson(body);
+  };
+
+  next();
+};
+

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -1,0 +1,31 @@
+import { Request } from "express";
+
+interface LogMeta {
+  [key: string]: any;
+}
+
+const baseLog = (
+  level: string,
+  req: Request | null,
+  message: string,
+  meta: LogMeta = {}
+) => {
+  const logEntry: LogMeta = { level, message, ...meta };
+  const requestId = (req as any)?.requestId;
+  if (requestId) {
+    logEntry.requestId = requestId;
+  }
+  console.log(JSON.stringify(logEntry));
+};
+
+export const logInfo = (
+  req: Request | null,
+  message: string,
+  meta: LogMeta = {}
+): void => baseLog("info", req, message, meta);
+
+export const logError = (
+  req: Request | null,
+  message: string,
+  meta: LogMeta = {}
+): void => baseLog("error", req, message, meta);


### PR DESCRIPTION
## Summary
- generate unique request IDs for each request and attach to responses
- log requests and application messages in JSON format including request IDs
- add reusable logger utility for CloudWatch-compatible structured logs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a97d9f2ac08328b9df326e110084d7