### PR TITLE
feat: enforce security headers and CSP

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+This project enforces a strict set of HTTP security headers for both the Next.js client and the Express server.
+
+## Headers
+
+- **Content-Security-Policy** – limits the origins for scripts, styles, images, fonts and other resources. The policy permits only resources from the application itself and uses a per-request nonce for inline scripts and styles.
+- **Strict-Transport-Security** – forces browsers to use HTTPS for all requests for two years and includes sub‑domains.
+- **X-Frame-Options** – set to `DENY` to prevent the site from being embedded in a frame.
+- **X-Content-Type-Options** – set to `nosniff` to disable MIME type sniffing.
+- **Referrer-Policy** – set to `same-origin`.
+
+## Nonce Usage
+
+A nonce is generated for every request and exposed to pages via the `x-nonce` request header. When authoring inline `<script>` or `<style>` tags, apply the nonce value:
+
+```tsx
+<script nonce={nonce}>/* inline code */</script>
+<style nonce={nonce}>/* inline css */</style>
+```
+
+The nonce is also available on the root `<html>` element as a `data-nonce` attribute for client-side access.
+
+## External Resources
+
+If the application needs to load external resources (CDNs, images, fonts, etc.), update the directives in `client/src/middleware.ts` so the domains are whitelisted in the Content Security Policy. Any new external dependency **must** be reviewed for CSP compliance before being merged.

--- a/client/README.md
+++ b/client/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Security Headers
+
+The application sends a strict Content Security Policy and other HTTP security headers. A per-request nonce is required for any inline scripts or styles. See the [Security Policy](../SECURITY.md) for details on updating the policy when adding external resources.

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
@@ -24,8 +25,9 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const nonce = headers().get("x-nonce") ?? "";
   return (
-    <html lang="en">
+    <html lang="en" data-nonce={nonce}>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const nonce = btoa(
+    String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16)))
+  );
+
+  const csp = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}'`,
+    `style-src 'self' 'nonce-${nonce}'`,
+    "img-src 'self' data:",
+    "connect-src 'self'",
+    "font-src 'self'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+  ].join('; ');
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+
+  response.headers.set('Content-Security-Policy', csp);
+  response.headers.set(
+    'Strict-Transport-Security',
+    'max-age=63072000; includeSubDomains; preload'
+  );
+  response.headers.set('X-Frame-Options', 'DENY');
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+  response.headers.set('Referrer-Policy', 'same-origin');
+
+  return response;
+}
+
+export const config = {
+  matcher: '/:path*',
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
 import { authMiddleware } from "./middleware/authMiddleware";
+import { securityHeaders } from "./middleware/securityHeaders";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenantRoutes";
 import managerRoutes from "./routes/managerRoutes";
@@ -22,6 +23,7 @@ app.use(morgan("common"));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cors());
+app.use(securityHeaders);
 
 /* ROUTES */
 app.get("/", (req, res) => {

--- a/server/src/middleware/securityHeaders.ts
+++ b/server/src/middleware/securityHeaders.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction } from "express";
+
+export const securityHeaders = (
+  _req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  res.setHeader(
+    "Content-Security-Policy",
+    "default-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'"
+  );
+  res.setHeader(
+    "Strict-Transport-Security",
+    "max-age=63072000; includeSubDomains; preload"
+  );
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Referrer-Policy", "same-origin");
+  next();
+};


### PR DESCRIPTION
## Summary
- add Next.js middleware setting CSP, HSTS, XFO, and nonce
- expose nonce to pages and document security policy
- secure Express API with matching headers

## Testing
- `npm run lint`
- `npm run build` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a97d9e71e48328a56676e1a29ec51b