### PR TITLE
Add Redis rate limiter and WAF bot mitigation config

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,10 +19,12 @@
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "helmet": "^8.0.0",
+        "ioredis": "^5.7.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
         "multer": "^1.4.5-lts.1",
         "prisma": "^6.3.0",
+        "rate-limiter-flexible": "^7.2.0",
         "uuid": "^11.0.5"
       },
       "devDependencies": {
@@ -924,6 +926,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.0.tgz",
+      "integrity": "sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2416,6 +2424,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2589,6 +2606,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -3194,6 +3220,53 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
+      "integrity": "sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.3.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3360,10 +3433,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
@@ -3894,6 +3979,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/rate-limiter-flexible": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-7.2.0.tgz",
+      "integrity": "sha512-hrf0vIS/WOBegnHg+uPXxsXhuQYlNGfZiCmK5Wgudb12xlZUhpv9yD23yp/EW6BKQosshqnIQRQV+r3jyfIGQg==",
+      "license": "ISC"
+    },
     "node_modules/raw-body": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
@@ -3953,6 +4044,27 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/require-directory": {
@@ -4304,6 +4416,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -25,10 +25,12 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "helmet": "^8.0.0",
+    "ioredis": "^5.7.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
     "prisma": "^6.3.0",
+    "rate-limiter-flexible": "^7.2.0",
     "uuid": "^11.0.5"
   },
   "devDependencies": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
 import { authMiddleware } from "./middleware/authMiddleware";
+import { rateLimiterMiddleware } from "./middleware/rateLimiter";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenantRoutes";
 import managerRoutes from "./routes/managerRoutes";
@@ -28,9 +29,9 @@ app.get("/", (req, res) => {
   res.send("This is home route");
 });
 
-app.use("/applications", applicationRoutes);
-app.use("/properties", propertyRoutes);
-app.use("/leases", leaseRoutes);
+app.use("/applications", rateLimiterMiddleware, applicationRoutes);
+app.use("/properties", rateLimiterMiddleware, propertyRoutes);
+app.use("/leases", rateLimiterMiddleware, leaseRoutes);
 app.use("/tenants", authMiddleware(["tenant"]), tenantRoutes);
 app.use("/managers", authMiddleware(["manager"]), managerRoutes);
 

--- a/server/src/middleware/rateLimiter.ts
+++ b/server/src/middleware/rateLimiter.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction } from "express";
+import { RateLimiterRedis } from "rate-limiter-flexible";
+import Redis from "ioredis";
+
+const redisClient = new Redis({
+  enableOfflineQueue: false,
+  host: process.env.REDIS_HOST || "127.0.0.1",
+  port: Number(process.env.REDIS_PORT) || 6379,
+});
+
+const rateLimiter = new RateLimiterRedis({
+  storeClient: redisClient,
+  points: 100,
+  duration: 60,
+  blockDuration: 300,
+});
+
+export const rateLimiterMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const ip = req.ip || "";
+  rateLimiter
+    .consume(ip)
+    .then(() => {
+      next();
+    })
+    .catch((rejRes) => {
+      const retrySecs = Math.ceil(rejRes.msBeforeNext / 1000);
+      if (rejRes.consumedPoints > 0) {
+        console.warn(`Rate limit exceeded for IP ${ip}`);
+      }
+      res.set("Retry-After", String(retrySecs));
+      res.status(429).send("Too Many Requests");
+    });
+};

--- a/server/waf/bot-mitigation.json
+++ b/server/waf/bot-mitigation.json
@@ -1,0 +1,35 @@
+{
+  "Description": "AWS WAF Bot Control configuration",
+  "Resources": {
+    "WebACL": {
+      "Type": "AWS::WAFv2::WebACL",
+      "Properties": {
+        "Scope": "REGIONAL",
+        "DefaultAction": { "Allow": {} },
+        "VisibilityConfig": {
+          "SampledRequestsEnabled": true,
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "webACL"
+        },
+        "Rules": [
+          {
+            "Name": "AWS-AWSManagedRulesBotControlRuleSet",
+            "Priority": 0,
+            "Statement": {
+              "ManagedRuleGroupStatement": {
+                "VendorName": "AWS",
+                "Name": "AWSManagedRulesBotControlRuleSet"
+              }
+            },
+            "OverrideAction": { "None": {} },
+            "VisibilityConfig": {
+              "SampledRequestsEnabled": true,
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "botControl"
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- integrate `rate-limiter-flexible` with Redis to throttle requests and log abuse
- apply rate limiting middleware to application, property, and lease routes
- add AWS WAF Bot Control configuration for bot mitigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a97d9d6e1c8328977ea778cce58aa9