### PR TITLE
Add API caching headers and SWR hook

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -49,6 +49,7 @@
         "react-hook-form": "^7.54.2",
         "react-redux": "^9.2.0",
         "sonner": "^1.7.4",
+        "swr": "^2.3.0",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.24.1"
@@ -6517,6 +6518,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -10459,6 +10469,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.0.tgz",
+      "integrity": "sha512-NyZ76wA4yElZWBHzSgEJc28a0u6QZvhb6w0azeL2k7+Q1gAzVK+IqQYXhVOC/mzi+HZIozrZvBVeSeOZNR2bqA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tailwind-merge": {

--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
     "react-hook-form": "^7.54.2",
     "react-redux": "^9.2.0",
     "sonner": "^1.7.4",
+    "swr": "^2.3.0",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.1"

--- a/client/src/hooks/use-api.ts
+++ b/client/src/hooks/use-api.ts
@@ -1,0 +1,19 @@
+import useSWR, { SWRConfiguration, SWRResponse } from "swr";
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error("Failed to fetch");
+  }
+  return res.json();
+};
+
+const defaultConfig: SWRConfiguration = {
+  revalidateOnFocus: false,
+  dedupingInterval: 60000,
+  keepPreviousData: true,
+};
+
+export function useApi<T>(key: string | null, config?: SWRConfiguration): SWRResponse<T, any> {
+  return useSWR<T>(key, fetcher, { ...defaultConfig, ...config });
+}

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,15 @@
+# Server
+
+## API Caching
+
+All API responses include a `Cache-Control` header to leverage HTTP caching.
+
+```
+Cache-Control: public, max-age=60, stale-while-revalidate=120
+```
+
+* **max-age=60** – Responses are considered fresh for 60 seconds.
+* **stale-while-revalidate=120** – After responses become stale, they may still be served for up to 120 seconds while the server revalidates them in the background.
+* **public/private** – Endpoints requiring authentication are marked `private` to prevent shared caches from storing user-specific data. All other GET endpoints use `public`.
+
+Clients should rely on these headers when fetching data. The accompanying SWR hook in the client defaults to a `dedupingInterval` of 60 seconds to align with `max-age`.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import helmet from "helmet";
 import morgan from "morgan";
 import { authMiddleware } from "./middleware/authMiddleware";
+import { cacheControl } from "./middleware/cacheControl";
 /* ROUTE IMPORT */
 import tenantRoutes from "./routes/tenantRoutes";
 import managerRoutes from "./routes/managerRoutes";
@@ -22,6 +23,7 @@ app.use(morgan("common"));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cors());
+app.use(cacheControl);
 
 /* ROUTES */
 app.get("/", (req, res) => {

--- a/server/src/middleware/cacheControl.ts
+++ b/server/src/middleware/cacheControl.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from "express";
+
+export function cacheControl(req: Request, res: Response, next: NextFunction) {
+  if (req.method === "GET") {
+    const isPrivate = req.path.startsWith("/tenants") || req.path.startsWith("/managers");
+    const visibility = isPrivate ? "private" : "public";
+    res.set(
+      "Cache-Control",
+      `${visibility}, max-age=60, stale-while-revalidate=120`
+    );
+  }
+  next();
+}


### PR DESCRIPTION
## Summary
- document server-side Cache-Control policy and apply middleware for GET routes
- add SWR-based `useApi` hook with default caching options
- include SWR dependency for client

## Testing
- `npm test` (client) *(fails: missing script)*
- `npm run lint`
- `npm test` (server) *(fails: missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a97d9d0380832888497456cd8583eb