### PR TITLE
feat: add Stripe webhook handling

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,6 +23,7 @@
         "morgan": "^1.10.0",
         "multer": "^1.4.5-lts.1",
         "prisma": "^6.3.0",
+        "stripe": "^16.12.0",
         "uuid": "^11.0.5"
       },
       "devDependencies": {
@@ -1922,7 +1923,6 @@
       "version": "22.13.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
       "integrity": "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -4465,6 +4465,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/stripe": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
+      "integrity": "sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
@@ -4636,7 +4649,6 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
     "prisma": "^6.3.0",
+    "stripe": "^16.12.0",
     "uuid": "^11.0.5"
   },
   "devDependencies": {

--- a/server/prisma/migrations/20250203030419_add_stripe_event/migration.sql
+++ b/server/prisma/migrations/20250203030419_add_stripe_event/migration.sql
@@ -1,0 +1,6 @@
+-- CreateTable
+CREATE TABLE "StripeEvent" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "StripeEvent_pkey" PRIMARY KEY ("id")
+);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -173,3 +173,8 @@ model Payment {
 
   lease Lease @relation(fields: [leaseId], references: [id])
 }
+
+model StripeEvent {
+  id        String   @id
+  createdAt DateTime @default(now())
+}

--- a/server/src/controllers/stripeController.ts
+++ b/server/src/controllers/stripeController.ts
@@ -1,0 +1,81 @@
+import { Request, Response } from "express";
+import Stripe from "stripe";
+import { PrismaClient, PaymentStatus } from "@prisma/client";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: "2024-06-20",
+});
+const prisma = new PrismaClient();
+
+export const handleStripeWebhook = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  const signature = req.headers["stripe-signature"] as string | undefined;
+  if (!signature) {
+    res.status(400).send("Missing stripe-signature header");
+    return;
+  }
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      req.body,
+      signature,
+      process.env.STRIPE_WEBHOOK_SECRET as string
+    );
+  } catch (err: any) {
+    res.status(400).send(`Webhook Error: ${err.message}`);
+    return;
+  }
+
+  // Prevent duplicate processing
+  const alreadyProcessed = await prisma.stripeEvent.findUnique({
+    where: { id: event.id },
+  });
+  if (alreadyProcessed) {
+    res.json({ received: true });
+    return;
+  }
+
+  try {
+    switch (event.type) {
+      case "payment_intent.succeeded": {
+        const paymentIntent = event.data.object as Stripe.PaymentIntent;
+        const paymentId = paymentIntent.metadata?.paymentId;
+        if (paymentId) {
+          await prisma.payment.update({
+            where: { id: Number(paymentId) },
+            data: {
+              paymentStatus: PaymentStatus.Paid,
+              amountPaid: paymentIntent.amount_received / 100,
+              paymentDate: new Date(),
+            },
+          });
+        }
+        break;
+      }
+      case "payment_intent.payment_failed": {
+        const paymentIntent = event.data.object as Stripe.PaymentIntent;
+        const paymentId = paymentIntent.metadata?.paymentId;
+        if (paymentId) {
+          await prisma.payment.update({
+            where: { id: Number(paymentId) },
+            data: {
+              paymentStatus: PaymentStatus.Overdue,
+            },
+          });
+        }
+        break;
+      }
+      default:
+        console.log(`Unhandled event type ${event.type}`);
+    }
+
+    await prisma.stripeEvent.create({ data: { id: event.id } });
+    res.json({ received: true });
+  } catch (error: any) {
+    console.error("Webhook handler failed", error);
+    res.status(500).send("Webhook handler failed");
+  }
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,10 +11,14 @@ import managerRoutes from "./routes/managerRoutes";
 import propertyRoutes from "./routes/propertyRoutes";
 import leaseRoutes from "./routes/leaseRoutes";
 import applicationRoutes from "./routes/applicationRoutes";
+import stripeRoutes from "./routes/stripeRoutes";
 
 /* CONFIGURATIONS */
 dotenv.config();
 const app = express();
+// Stripe webhook must be registered before body parsing middleware
+app.use("/api/stripe", stripeRoutes);
+
 app.use(express.json());
 app.use(helmet());
 app.use(helmet.crossOriginResourcePolicy({ policy: "cross-origin" }));

--- a/server/src/routes/stripeRoutes.ts
+++ b/server/src/routes/stripeRoutes.ts
@@ -1,0 +1,13 @@
+import express from "express";
+import { handleStripeWebhook } from "../controllers/stripeController";
+
+const router = express.Router();
+
+// Stripe needs raw body to validate signature
+router.post(
+  "/webhook",
+  express.raw({ type: "application/json" }),
+  handleStripeWebhook
+);
+
+export default router;


### PR DESCRIPTION
## Summary
- add Stripe webhook endpoint with signature verification
- record processed Stripe events to avoid duplicates
- update payment status based on incoming Stripe events

## Testing
- `npx prisma generate`
- `npm run build`
- `npx prisma migrate dev --name add-stripe-event --create-only` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_68a97d9822a08328977e85978d286a25