### PR TITLE
Add SMS notifications with opt-in preferences

### DIFF
--- a/client/src/types/prismaTypes.d.ts
+++ b/client/src/types/prismaTypes.d.ts
@@ -29,6 +29,11 @@ export type Manager = $Result.DefaultSelection<Prisma.$ManagerPayload>
  */
 export type Tenant = $Result.DefaultSelection<Prisma.$TenantPayload>
 /**
+ * Model SmsLog
+ * 
+ */
+export type SmsLog = $Result.DefaultSelection<Prisma.$SmsLogPayload>
+/**
  * Model Location
  * 
  */
@@ -299,6 +304,16 @@ export class PrismaClient<
     * ```
     */
   get tenant(): Prisma.TenantDelegate<ExtArgs, ClientOptions>;
+
+  /**
+   * `prisma.smsLog`: Exposes CRUD operations for the **SmsLog** model.
+    * Example usage:
+    * ```ts
+    * // Fetch zero or more SmsLogs
+    * const smsLogs = await prisma.smsLog.findMany()
+    * ```
+    */
+  get smsLog(): Prisma.SmsLogDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.location`: Exposes CRUD operations for the **Location** model.
@@ -782,6 +797,7 @@ export namespace Prisma {
     Property: 'Property',
     Manager: 'Manager',
     Tenant: 'Tenant',
+    SmsLog: 'SmsLog',
     Location: 'Location',
     Application: 'Application',
     Lease: 'Lease',
@@ -801,7 +817,7 @@ export namespace Prisma {
 
   export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, ClientOptions = {}> = {
     meta: {
-      modelProps: "property" | "manager" | "tenant" | "location" | "application" | "lease" | "payment"
+      modelProps: "property" | "manager" | "tenant" | "smsLog" | "location" | "application" | "lease" | "payment"
       txIsolationLevel: Prisma.TransactionIsolationLevel
     }
     model: {
@@ -1024,6 +1040,80 @@ export namespace Prisma {
           count: {
             args: Prisma.TenantCountArgs<ExtArgs>
             result: $Utils.Optional<TenantCountAggregateOutputType> | number
+          }
+        }
+      }
+      SmsLog: {
+        payload: Prisma.$SmsLogPayload<ExtArgs>
+        fields: Prisma.SmsLogFieldRefs
+        operations: {
+          findUnique: {
+            args: Prisma.SmsLogFindUniqueArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$SmsLogPayload> | null
+          }
+          findUniqueOrThrow: {
+            args: Prisma.SmsLogFindUniqueOrThrowArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$SmsLogPayload>
+          }
+          findFirst: {
+            args: Prisma.SmsLogFindFirstArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$SmsLogPayload> | null
+          }
+          findFirstOrThrow: {
+            args: Prisma.SmsLogFindFirstOrThrowArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$SmsLogPayload>
+          }
+          findMany: {
+            args: Prisma.SmsLogFindManyArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$SmsLogPayload>[]
+          }
+          create: {
+            args: Prisma.SmsLogCreateArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$SmsLogPayload>
+          }
+          createMany: {
+            args: Prisma.SmsLogCreateManyArgs<ExtArgs>
+            result: BatchPayload
+          }
+          createManyAndReturn: {
+            args: Prisma.SmsLogCreateManyAndReturnArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$SmsLogPayload>[]
+          }
+          delete: {
+            args: Prisma.SmsLogDeleteArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$SmsLogPayload>
+          }
+          update: {
+            args: Prisma.SmsLogUpdateArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$SmsLogPayload>
+          }
+          deleteMany: {
+            args: Prisma.SmsLogDeleteManyArgs<ExtArgs>
+            result: BatchPayload
+          }
+          updateMany: {
+            args: Prisma.SmsLogUpdateManyArgs<ExtArgs>
+            result: BatchPayload
+          }
+          updateManyAndReturn: {
+            args: Prisma.SmsLogUpdateManyAndReturnArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$SmsLogPayload>[]
+          }
+          upsert: {
+            args: Prisma.SmsLogUpsertArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$SmsLogPayload>
+          }
+          aggregate: {
+            args: Prisma.SmsLogAggregateArgs<ExtArgs>
+            result: $Utils.Optional<AggregateSmsLog>
+          }
+          groupBy: {
+            args: Prisma.SmsLogGroupByArgs<ExtArgs>
+            result: $Utils.Optional<SmsLogGroupByOutputType>[]
+          }
+          count: {
+            args: Prisma.SmsLogCountArgs<ExtArgs>
+            result: $Utils.Optional<SmsLogCountAggregateOutputType> | number
           }
         }
       }
@@ -1394,6 +1484,7 @@ export namespace Prisma {
     property?: PropertyOmit
     manager?: ManagerOmit
     tenant?: TenantOmit
+    smsLog?: SmsLogOmit
     location?: LocationOmit
     application?: ApplicationOmit
     lease?: LeaseOmit
@@ -3159,6 +3250,7 @@ export namespace Prisma {
     name: string | null
     email: string | null
     phoneNumber: string | null
+    smsOptIn: boolean | null
   }
 
   export type ManagerMaxAggregateOutputType = {
@@ -3167,6 +3259,7 @@ export namespace Prisma {
     name: string | null
     email: string | null
     phoneNumber: string | null
+    smsOptIn: boolean | null
   }
 
   export type ManagerCountAggregateOutputType = {
@@ -3175,6 +3268,7 @@ export namespace Prisma {
     name: number
     email: number
     phoneNumber: number
+    smsOptIn: number
     _all: number
   }
 
@@ -3193,6 +3287,7 @@ export namespace Prisma {
     name?: true
     email?: true
     phoneNumber?: true
+    smsOptIn?: true
   }
 
   export type ManagerMaxAggregateInputType = {
@@ -3201,6 +3296,7 @@ export namespace Prisma {
     name?: true
     email?: true
     phoneNumber?: true
+    smsOptIn?: true
   }
 
   export type ManagerCountAggregateInputType = {
@@ -3209,6 +3305,7 @@ export namespace Prisma {
     name?: true
     email?: true
     phoneNumber?: true
+    smsOptIn?: true
     _all?: true
   }
 
@@ -3304,6 +3401,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn: boolean
     _count: ManagerCountAggregateOutputType | null
     _avg: ManagerAvgAggregateOutputType | null
     _sum: ManagerSumAggregateOutputType | null
@@ -3331,6 +3429,7 @@ export namespace Prisma {
     name?: boolean
     email?: boolean
     phoneNumber?: boolean
+    smsOptIn?: boolean
     managedProperties?: boolean | Manager$managedPropertiesArgs<ExtArgs>
     _count?: boolean | ManagerCountOutputTypeDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["manager"]>
@@ -3341,6 +3440,7 @@ export namespace Prisma {
     name?: boolean
     email?: boolean
     phoneNumber?: boolean
+    smsOptIn?: boolean
   }, ExtArgs["result"]["manager"]>
 
   export type ManagerSelectUpdateManyAndReturn<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
@@ -3349,6 +3449,7 @@ export namespace Prisma {
     name?: boolean
     email?: boolean
     phoneNumber?: boolean
+    smsOptIn?: boolean
   }, ExtArgs["result"]["manager"]>
 
   export type ManagerSelectScalar = {
@@ -3357,9 +3458,10 @@ export namespace Prisma {
     name?: boolean
     email?: boolean
     phoneNumber?: boolean
+    smsOptIn?: boolean
   }
 
-  export type ManagerOmit<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetOmit<"id" | "cognitoId" | "name" | "email" | "phoneNumber", ExtArgs["result"]["manager"]>
+  export type ManagerOmit<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetOmit<"id" | "cognitoId" | "name" | "email" | "phoneNumber" | "smsOptIn", ExtArgs["result"]["manager"]>
   export type ManagerInclude<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
     managedProperties?: boolean | Manager$managedPropertiesArgs<ExtArgs>
     _count?: boolean | ManagerCountOutputTypeDefaultArgs<ExtArgs>
@@ -3378,6 +3480,7 @@ export namespace Prisma {
       name: string
       email: string
       phoneNumber: string
+      smsOptIn: boolean
     }, ExtArgs["result"]["manager"]>
     composites: {}
   }
@@ -3807,6 +3910,7 @@ export namespace Prisma {
     readonly name: FieldRef<"Manager", 'String'>
     readonly email: FieldRef<"Manager", 'String'>
     readonly phoneNumber: FieldRef<"Manager", 'String'>
+    readonly smsOptIn: FieldRef<"Manager", 'Boolean'>
   }
     
 
@@ -4263,6 +4367,7 @@ export namespace Prisma {
     name: string | null
     email: string | null
     phoneNumber: string | null
+    smsOptIn: boolean | null
   }
 
   export type TenantMaxAggregateOutputType = {
@@ -4271,6 +4376,7 @@ export namespace Prisma {
     name: string | null
     email: string | null
     phoneNumber: string | null
+    smsOptIn: boolean | null
   }
 
   export type TenantCountAggregateOutputType = {
@@ -4279,6 +4385,7 @@ export namespace Prisma {
     name: number
     email: number
     phoneNumber: number
+    smsOptIn: number
     _all: number
   }
 
@@ -4297,6 +4404,7 @@ export namespace Prisma {
     name?: true
     email?: true
     phoneNumber?: true
+    smsOptIn?: true
   }
 
   export type TenantMaxAggregateInputType = {
@@ -4305,6 +4413,7 @@ export namespace Prisma {
     name?: true
     email?: true
     phoneNumber?: true
+    smsOptIn?: true
   }
 
   export type TenantCountAggregateInputType = {
@@ -4313,6 +4422,7 @@ export namespace Prisma {
     name?: true
     email?: true
     phoneNumber?: true
+    smsOptIn?: true
     _all?: true
   }
 
@@ -4408,6 +4518,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn: boolean
     _count: TenantCountAggregateOutputType | null
     _avg: TenantAvgAggregateOutputType | null
     _sum: TenantSumAggregateOutputType | null
@@ -4435,6 +4546,7 @@ export namespace Prisma {
     name?: boolean
     email?: boolean
     phoneNumber?: boolean
+    smsOptIn?: boolean
     properties?: boolean | Tenant$propertiesArgs<ExtArgs>
     favorites?: boolean | Tenant$favoritesArgs<ExtArgs>
     applications?: boolean | Tenant$applicationsArgs<ExtArgs>
@@ -4448,6 +4560,7 @@ export namespace Prisma {
     name?: boolean
     email?: boolean
     phoneNumber?: boolean
+    smsOptIn?: boolean
   }, ExtArgs["result"]["tenant"]>
 
   export type TenantSelectUpdateManyAndReturn<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
@@ -4456,6 +4569,7 @@ export namespace Prisma {
     name?: boolean
     email?: boolean
     phoneNumber?: boolean
+    smsOptIn?: boolean
   }, ExtArgs["result"]["tenant"]>
 
   export type TenantSelectScalar = {
@@ -4464,9 +4578,10 @@ export namespace Prisma {
     name?: boolean
     email?: boolean
     phoneNumber?: boolean
+    smsOptIn?: boolean
   }
 
-  export type TenantOmit<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetOmit<"id" | "cognitoId" | "name" | "email" | "phoneNumber", ExtArgs["result"]["tenant"]>
+  export type TenantOmit<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetOmit<"id" | "cognitoId" | "name" | "email" | "phoneNumber" | "smsOptIn", ExtArgs["result"]["tenant"]>
   export type TenantInclude<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
     properties?: boolean | Tenant$propertiesArgs<ExtArgs>
     favorites?: boolean | Tenant$favoritesArgs<ExtArgs>
@@ -4491,6 +4606,7 @@ export namespace Prisma {
       name: string
       email: string
       phoneNumber: string
+      smsOptIn: boolean
     }, ExtArgs["result"]["tenant"]>
     composites: {}
   }
@@ -4923,6 +5039,7 @@ export namespace Prisma {
     readonly name: FieldRef<"Tenant", 'String'>
     readonly email: FieldRef<"Tenant", 'String'>
     readonly phoneNumber: FieldRef<"Tenant", 'String'>
+    readonly smsOptIn: FieldRef<"Tenant", 'Boolean'>
   }
     
 
@@ -5422,6 +5539,1074 @@ export namespace Prisma {
      * Choose, which related nodes to fetch as well
      */
     include?: TenantInclude<ExtArgs> | null
+  }
+
+
+  /**
+   * Model SmsLog
+   */
+
+  export type AggregateSmsLog = {
+    _count: SmsLogCountAggregateOutputType | null
+    _avg: SmsLogAvgAggregateOutputType | null
+    _sum: SmsLogSumAggregateOutputType | null
+    _min: SmsLogMinAggregateOutputType | null
+    _max: SmsLogMaxAggregateOutputType | null
+  }
+
+  export type SmsLogAvgAggregateOutputType = {
+    id: number | null
+  }
+
+  export type SmsLogSumAggregateOutputType = {
+    id: number | null
+  }
+
+  export type SmsLogMinAggregateOutputType = {
+    id: number | null
+    cognitoId: string | null
+    userType: string | null
+    message: string | null
+    status: string | null
+    messageId: string | null
+    error: string | null
+    createdAt: Date | null
+  }
+
+  export type SmsLogMaxAggregateOutputType = {
+    id: number | null
+    cognitoId: string | null
+    userType: string | null
+    message: string | null
+    status: string | null
+    messageId: string | null
+    error: string | null
+    createdAt: Date | null
+  }
+
+  export type SmsLogCountAggregateOutputType = {
+    id: number
+    cognitoId: number
+    userType: number
+    message: number
+    status: number
+    messageId: number
+    error: number
+    createdAt: number
+    _all: number
+  }
+
+
+  export type SmsLogAvgAggregateInputType = {
+    id?: true
+  }
+
+  export type SmsLogSumAggregateInputType = {
+    id?: true
+  }
+
+  export type SmsLogMinAggregateInputType = {
+    id?: true
+    cognitoId?: true
+    userType?: true
+    message?: true
+    status?: true
+    messageId?: true
+    error?: true
+    createdAt?: true
+  }
+
+  export type SmsLogMaxAggregateInputType = {
+    id?: true
+    cognitoId?: true
+    userType?: true
+    message?: true
+    status?: true
+    messageId?: true
+    error?: true
+    createdAt?: true
+  }
+
+  export type SmsLogCountAggregateInputType = {
+    id?: true
+    cognitoId?: true
+    userType?: true
+    message?: true
+    status?: true
+    messageId?: true
+    error?: true
+    createdAt?: true
+    _all?: true
+  }
+
+  export type SmsLogAggregateArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Filter which SmsLog to aggregate.
+     */
+    where?: SmsLogWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of SmsLogs to fetch.
+     */
+    orderBy?: SmsLogOrderByWithRelationInput | SmsLogOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     */
+    cursor?: SmsLogWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` SmsLogs from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` SmsLogs.
+     */
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned SmsLogs
+    **/
+    _count?: true | SmsLogCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: SmsLogAvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: SmsLogSumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: SmsLogMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: SmsLogMaxAggregateInputType
+  }
+
+  export type GetSmsLogAggregateType<T extends SmsLogAggregateArgs> = {
+        [P in keyof T & keyof AggregateSmsLog]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateSmsLog[P]>
+      : GetScalarType<T[P], AggregateSmsLog[P]>
+  }
+
+
+
+
+  export type SmsLogGroupByArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    where?: SmsLogWhereInput
+    orderBy?: SmsLogOrderByWithAggregationInput | SmsLogOrderByWithAggregationInput[]
+    by: SmsLogScalarFieldEnum[] | SmsLogScalarFieldEnum
+    having?: SmsLogScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: SmsLogCountAggregateInputType | true
+    _avg?: SmsLogAvgAggregateInputType
+    _sum?: SmsLogSumAggregateInputType
+    _min?: SmsLogMinAggregateInputType
+    _max?: SmsLogMaxAggregateInputType
+  }
+
+  export type SmsLogGroupByOutputType = {
+    id: number
+    cognitoId: string
+    userType: string
+    message: string
+    status: string
+    messageId: string | null
+    error: string | null
+    createdAt: Date
+    _count: SmsLogCountAggregateOutputType | null
+    _avg: SmsLogAvgAggregateOutputType | null
+    _sum: SmsLogSumAggregateOutputType | null
+    _min: SmsLogMinAggregateOutputType | null
+    _max: SmsLogMaxAggregateOutputType | null
+  }
+
+  type GetSmsLogGroupByPayload<T extends SmsLogGroupByArgs> = Prisma.PrismaPromise<
+    Array<
+      PickEnumerable<SmsLogGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof SmsLogGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], SmsLogGroupByOutputType[P]>
+            : GetScalarType<T[P], SmsLogGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type SmsLogSelect<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
+    id?: boolean
+    cognitoId?: boolean
+    userType?: boolean
+    message?: boolean
+    status?: boolean
+    messageId?: boolean
+    error?: boolean
+    createdAt?: boolean
+  }, ExtArgs["result"]["smsLog"]>
+
+  export type SmsLogSelectCreateManyAndReturn<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
+    id?: boolean
+    cognitoId?: boolean
+    userType?: boolean
+    message?: boolean
+    status?: boolean
+    messageId?: boolean
+    error?: boolean
+    createdAt?: boolean
+  }, ExtArgs["result"]["smsLog"]>
+
+  export type SmsLogSelectUpdateManyAndReturn<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
+    id?: boolean
+    cognitoId?: boolean
+    userType?: boolean
+    message?: boolean
+    status?: boolean
+    messageId?: boolean
+    error?: boolean
+    createdAt?: boolean
+  }, ExtArgs["result"]["smsLog"]>
+
+  export type SmsLogSelectScalar = {
+    id?: boolean
+    cognitoId?: boolean
+    userType?: boolean
+    message?: boolean
+    status?: boolean
+    messageId?: boolean
+    error?: boolean
+    createdAt?: boolean
+  }
+
+  export type SmsLogOmit<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetOmit<"id" | "cognitoId" | "userType" | "message" | "status" | "messageId" | "error" | "createdAt", ExtArgs["result"]["smsLog"]>
+
+  export type $SmsLogPayload<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    name: "SmsLog"
+    objects: {}
+    scalars: $Extensions.GetPayloadResult<{
+      id: number
+      cognitoId: string
+      userType: string
+      message: string
+      status: string
+      messageId: string | null
+      error: string | null
+      createdAt: Date
+    }, ExtArgs["result"]["smsLog"]>
+    composites: {}
+  }
+
+  type SmsLogGetPayload<S extends boolean | null | undefined | SmsLogDefaultArgs> = $Result.GetResult<Prisma.$SmsLogPayload, S>
+
+  type SmsLogCountArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> =
+    Omit<SmsLogFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
+      select?: SmsLogCountAggregateInputType | true
+    }
+
+  export interface SmsLogDelegate<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, ClientOptions = {}> {
+    [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['model']['SmsLog'], meta: { name: 'SmsLog' } }
+    /**
+     * Find zero or one SmsLog that matches the filter.
+     * @param {SmsLogFindUniqueArgs} args - Arguments to find a SmsLog
+     * @example
+     * // Get one SmsLog
+     * const smsLog = await prisma.smsLog.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findUnique<T extends SmsLogFindUniqueArgs>(args: SelectSubset<T, SmsLogFindUniqueArgs<ExtArgs>>): Prisma__SmsLogClient<$Result.GetResult<Prisma.$SmsLogPayload<ExtArgs>, T, "findUnique", ClientOptions> | null, null, ExtArgs, ClientOptions>
+
+    /**
+     * Find one SmsLog that matches the filter or throw an error with `error.code='P2025'`
+     * if no matches were found.
+     * @param {SmsLogFindUniqueOrThrowArgs} args - Arguments to find a SmsLog
+     * @example
+     * // Get one SmsLog
+     * const smsLog = await prisma.smsLog.findUniqueOrThrow({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findUniqueOrThrow<T extends SmsLogFindUniqueOrThrowArgs>(args: SelectSubset<T, SmsLogFindUniqueOrThrowArgs<ExtArgs>>): Prisma__SmsLogClient<$Result.GetResult<Prisma.$SmsLogPayload<ExtArgs>, T, "findUniqueOrThrow", ClientOptions>, never, ExtArgs, ClientOptions>
+
+    /**
+     * Find the first SmsLog that matches the filter.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {SmsLogFindFirstArgs} args - Arguments to find a SmsLog
+     * @example
+     * // Get one SmsLog
+     * const smsLog = await prisma.smsLog.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findFirst<T extends SmsLogFindFirstArgs>(args?: SelectSubset<T, SmsLogFindFirstArgs<ExtArgs>>): Prisma__SmsLogClient<$Result.GetResult<Prisma.$SmsLogPayload<ExtArgs>, T, "findFirst", ClientOptions> | null, null, ExtArgs, ClientOptions>
+
+    /**
+     * Find the first SmsLog that matches the filter or
+     * throw `PrismaKnownClientError` with `P2025` code if no matches were found.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {SmsLogFindFirstOrThrowArgs} args - Arguments to find a SmsLog
+     * @example
+     * // Get one SmsLog
+     * const smsLog = await prisma.smsLog.findFirstOrThrow({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findFirstOrThrow<T extends SmsLogFindFirstOrThrowArgs>(args?: SelectSubset<T, SmsLogFindFirstOrThrowArgs<ExtArgs>>): Prisma__SmsLogClient<$Result.GetResult<Prisma.$SmsLogPayload<ExtArgs>, T, "findFirstOrThrow", ClientOptions>, never, ExtArgs, ClientOptions>
+
+    /**
+     * Find zero or more SmsLogs that matches the filter.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {SmsLogFindManyArgs} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all SmsLogs
+     * const smsLogs = await prisma.smsLog.findMany()
+     * 
+     * // Get first 10 SmsLogs
+     * const smsLogs = await prisma.smsLog.findMany({ take: 10 })
+     * 
+     * // Only select the `id`
+     * const smsLogWithIdOnly = await prisma.smsLog.findMany({ select: { id: true } })
+     * 
+     */
+    findMany<T extends SmsLogFindManyArgs>(args?: SelectSubset<T, SmsLogFindManyArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$SmsLogPayload<ExtArgs>, T, "findMany", ClientOptions>>
+
+    /**
+     * Create a SmsLog.
+     * @param {SmsLogCreateArgs} args - Arguments to create a SmsLog.
+     * @example
+     * // Create one SmsLog
+     * const SmsLog = await prisma.smsLog.create({
+     *   data: {
+     *     // ... data to create a SmsLog
+     *   }
+     * })
+     * 
+     */
+    create<T extends SmsLogCreateArgs>(args: SelectSubset<T, SmsLogCreateArgs<ExtArgs>>): Prisma__SmsLogClient<$Result.GetResult<Prisma.$SmsLogPayload<ExtArgs>, T, "create", ClientOptions>, never, ExtArgs, ClientOptions>
+
+    /**
+     * Create many SmsLogs.
+     * @param {SmsLogCreateManyArgs} args - Arguments to create many SmsLogs.
+     * @example
+     * // Create many SmsLogs
+     * const smsLog = await prisma.smsLog.createMany({
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *     
+     */
+    createMany<T extends SmsLogCreateManyArgs>(args?: SelectSubset<T, SmsLogCreateManyArgs<ExtArgs>>): Prisma.PrismaPromise<BatchPayload>
+
+    /**
+     * Create many SmsLogs and returns the data saved in the database.
+     * @param {SmsLogCreateManyAndReturnArgs} args - Arguments to create many SmsLogs.
+     * @example
+     * // Create many SmsLogs
+     * const smsLog = await prisma.smsLog.createManyAndReturn({
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * 
+     * // Create many SmsLogs and only return the `id`
+     * const smsLogWithIdOnly = await prisma.smsLog.createManyAndReturn({
+     *   select: { id: true },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * 
+     */
+    createManyAndReturn<T extends SmsLogCreateManyAndReturnArgs>(args?: SelectSubset<T, SmsLogCreateManyAndReturnArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$SmsLogPayload<ExtArgs>, T, "createManyAndReturn", ClientOptions>>
+
+    /**
+     * Delete a SmsLog.
+     * @param {SmsLogDeleteArgs} args - Arguments to delete one SmsLog.
+     * @example
+     * // Delete one SmsLog
+     * const SmsLog = await prisma.smsLog.delete({
+     *   where: {
+     *     // ... filter to delete one SmsLog
+     *   }
+     * })
+     * 
+     */
+    delete<T extends SmsLogDeleteArgs>(args: SelectSubset<T, SmsLogDeleteArgs<ExtArgs>>): Prisma__SmsLogClient<$Result.GetResult<Prisma.$SmsLogPayload<ExtArgs>, T, "delete", ClientOptions>, never, ExtArgs, ClientOptions>
+
+    /**
+     * Update one SmsLog.
+     * @param {SmsLogUpdateArgs} args - Arguments to update one SmsLog.
+     * @example
+     * // Update one SmsLog
+     * const smsLog = await prisma.smsLog.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+     */
+    update<T extends SmsLogUpdateArgs>(args: SelectSubset<T, SmsLogUpdateArgs<ExtArgs>>): Prisma__SmsLogClient<$Result.GetResult<Prisma.$SmsLogPayload<ExtArgs>, T, "update", ClientOptions>, never, ExtArgs, ClientOptions>
+
+    /**
+     * Delete zero or more SmsLogs.
+     * @param {SmsLogDeleteManyArgs} args - Arguments to filter SmsLogs to delete.
+     * @example
+     * // Delete a few SmsLogs
+     * const { count } = await prisma.smsLog.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+     */
+    deleteMany<T extends SmsLogDeleteManyArgs>(args?: SelectSubset<T, SmsLogDeleteManyArgs<ExtArgs>>): Prisma.PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more SmsLogs.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {SmsLogUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many SmsLogs
+     * const smsLog = await prisma.smsLog.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+     */
+    updateMany<T extends SmsLogUpdateManyArgs>(args: SelectSubset<T, SmsLogUpdateManyArgs<ExtArgs>>): Prisma.PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more SmsLogs and returns the data updated in the database.
+     * @param {SmsLogUpdateManyAndReturnArgs} args - Arguments to update many SmsLogs.
+     * @example
+     * // Update many SmsLogs
+     * const smsLog = await prisma.smsLog.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * 
+     * // Update zero or more SmsLogs and only return the `id`
+     * const smsLogWithIdOnly = await prisma.smsLog.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * 
+     */
+    updateManyAndReturn<T extends SmsLogUpdateManyAndReturnArgs>(args: SelectSubset<T, SmsLogUpdateManyAndReturnArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$SmsLogPayload<ExtArgs>, T, "updateManyAndReturn", ClientOptions>>
+
+    /**
+     * Create or update one SmsLog.
+     * @param {SmsLogUpsertArgs} args - Arguments to update or create a SmsLog.
+     * @example
+     * // Update or create a SmsLog
+     * const smsLog = await prisma.smsLog.upsert({
+     *   create: {
+     *     // ... data to create a SmsLog
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the SmsLog we want to update
+     *   }
+     * })
+     */
+    upsert<T extends SmsLogUpsertArgs>(args: SelectSubset<T, SmsLogUpsertArgs<ExtArgs>>): Prisma__SmsLogClient<$Result.GetResult<Prisma.$SmsLogPayload<ExtArgs>, T, "upsert", ClientOptions>, never, ExtArgs, ClientOptions>
+
+
+    /**
+     * Count the number of SmsLogs.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {SmsLogCountArgs} args - Arguments to filter SmsLogs to count.
+     * @example
+     * // Count the number of SmsLogs
+     * const count = await prisma.smsLog.count({
+     *   where: {
+     *     // ... the filter for the SmsLogs we want to count
+     *   }
+     * })
+    **/
+    count<T extends SmsLogCountArgs>(
+      args?: Subset<T, SmsLogCountArgs>,
+    ): Prisma.PrismaPromise<
+      T extends $Utils.Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], SmsLogCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a SmsLog.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {SmsLogAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends SmsLogAggregateArgs>(args: Subset<T, SmsLogAggregateArgs>): Prisma.PrismaPromise<GetSmsLogAggregateType<T>>
+
+    /**
+     * Group by SmsLog.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {SmsLogGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends SmsLogGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: SmsLogGroupByArgs['orderBy'] }
+        : { orderBy?: SmsLogGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? `Error: "by" must not be empty.`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? `Error: Field "${P}" used in "having" needs to be provided in "by".`
+            : [
+                Error,
+                'Field ',
+                P,
+                ` in "having" needs to be provided in "by"`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, SmsLogGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetSmsLogGroupByPayload<T> : Prisma.PrismaPromise<InputErrors>
+  /**
+   * Fields of the SmsLog model
+   */
+  readonly fields: SmsLogFieldRefs;
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for SmsLog.
+   * Why is this prefixed with `Prisma__`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export interface Prisma__SmsLogClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, ClientOptions = {}> extends Prisma.PrismaPromise<T> {
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
+  }
+
+
+
+
+  /**
+   * Fields of the SmsLog model
+   */ 
+  interface SmsLogFieldRefs {
+    readonly id: FieldRef<"SmsLog", 'Int'>
+    readonly cognitoId: FieldRef<"SmsLog", 'String'>
+    readonly userType: FieldRef<"SmsLog", 'String'>
+    readonly message: FieldRef<"SmsLog", 'String'>
+    readonly status: FieldRef<"SmsLog", 'String'>
+    readonly messageId: FieldRef<"SmsLog", 'String'>
+    readonly error: FieldRef<"SmsLog", 'String'>
+    readonly createdAt: FieldRef<"SmsLog", 'DateTime'>
+  }
+    
+
+  // Custom InputTypes
+  /**
+   * SmsLog findUnique
+   */
+  export type SmsLogFindUniqueArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
+    /**
+     * Filter, which SmsLog to fetch.
+     */
+    where: SmsLogWhereUniqueInput
+  }
+
+  /**
+   * SmsLog findUniqueOrThrow
+   */
+  export type SmsLogFindUniqueOrThrowArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
+    /**
+     * Filter, which SmsLog to fetch.
+     */
+    where: SmsLogWhereUniqueInput
+  }
+
+  /**
+   * SmsLog findFirst
+   */
+  export type SmsLogFindFirstArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
+    /**
+     * Filter, which SmsLog to fetch.
+     */
+    where?: SmsLogWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of SmsLogs to fetch.
+     */
+    orderBy?: SmsLogOrderByWithRelationInput | SmsLogOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for SmsLogs.
+     */
+    cursor?: SmsLogWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` SmsLogs from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` SmsLogs.
+     */
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of SmsLogs.
+     */
+    distinct?: SmsLogScalarFieldEnum | SmsLogScalarFieldEnum[]
+  }
+
+  /**
+   * SmsLog findFirstOrThrow
+   */
+  export type SmsLogFindFirstOrThrowArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
+    /**
+     * Filter, which SmsLog to fetch.
+     */
+    where?: SmsLogWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of SmsLogs to fetch.
+     */
+    orderBy?: SmsLogOrderByWithRelationInput | SmsLogOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for SmsLogs.
+     */
+    cursor?: SmsLogWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` SmsLogs from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` SmsLogs.
+     */
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of SmsLogs.
+     */
+    distinct?: SmsLogScalarFieldEnum | SmsLogScalarFieldEnum[]
+  }
+
+  /**
+   * SmsLog findMany
+   */
+  export type SmsLogFindManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
+    /**
+     * Filter, which SmsLogs to fetch.
+     */
+    where?: SmsLogWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of SmsLogs to fetch.
+     */
+    orderBy?: SmsLogOrderByWithRelationInput | SmsLogOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing SmsLogs.
+     */
+    cursor?: SmsLogWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` SmsLogs from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` SmsLogs.
+     */
+    skip?: number
+    distinct?: SmsLogScalarFieldEnum | SmsLogScalarFieldEnum[]
+  }
+
+  /**
+   * SmsLog create
+   */
+  export type SmsLogCreateArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
+    /**
+     * The data needed to create a SmsLog.
+     */
+    data: XOR<SmsLogCreateInput, SmsLogUncheckedCreateInput>
+  }
+
+  /**
+   * SmsLog createMany
+   */
+  export type SmsLogCreateManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * The data used to create many SmsLogs.
+     */
+    data: SmsLogCreateManyInput | SmsLogCreateManyInput[]
+    skipDuplicates?: boolean
+  }
+
+  /**
+   * SmsLog createManyAndReturn
+   */
+  export type SmsLogCreateManyAndReturnArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelectCreateManyAndReturn<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
+    /**
+     * The data used to create many SmsLogs.
+     */
+    data: SmsLogCreateManyInput | SmsLogCreateManyInput[]
+    skipDuplicates?: boolean
+  }
+
+  /**
+   * SmsLog update
+   */
+  export type SmsLogUpdateArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
+    /**
+     * The data needed to update a SmsLog.
+     */
+    data: XOR<SmsLogUpdateInput, SmsLogUncheckedUpdateInput>
+    /**
+     * Choose, which SmsLog to update.
+     */
+    where: SmsLogWhereUniqueInput
+  }
+
+  /**
+   * SmsLog updateMany
+   */
+  export type SmsLogUpdateManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * The data used to update SmsLogs.
+     */
+    data: XOR<SmsLogUpdateManyMutationInput, SmsLogUncheckedUpdateManyInput>
+    /**
+     * Filter which SmsLogs to update
+     */
+    where?: SmsLogWhereInput
+    /**
+     * Limit how many SmsLogs to update.
+     */
+    limit?: number
+  }
+
+  /**
+   * SmsLog updateManyAndReturn
+   */
+  export type SmsLogUpdateManyAndReturnArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelectUpdateManyAndReturn<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
+    /**
+     * The data used to update SmsLogs.
+     */
+    data: XOR<SmsLogUpdateManyMutationInput, SmsLogUncheckedUpdateManyInput>
+    /**
+     * Filter which SmsLogs to update
+     */
+    where?: SmsLogWhereInput
+    /**
+     * Limit how many SmsLogs to update.
+     */
+    limit?: number
+  }
+
+  /**
+   * SmsLog upsert
+   */
+  export type SmsLogUpsertArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
+    /**
+     * The filter to search for the SmsLog to update in case it exists.
+     */
+    where: SmsLogWhereUniqueInput
+    /**
+     * In case the SmsLog found by the `where` argument doesn't exist, create a new SmsLog with this data.
+     */
+    create: XOR<SmsLogCreateInput, SmsLogUncheckedCreateInput>
+    /**
+     * In case the SmsLog was found with the provided `where` argument, update it with this data.
+     */
+    update: XOR<SmsLogUpdateInput, SmsLogUncheckedUpdateInput>
+  }
+
+  /**
+   * SmsLog delete
+   */
+  export type SmsLogDeleteArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
+    /**
+     * Filter which SmsLog to delete.
+     */
+    where: SmsLogWhereUniqueInput
+  }
+
+  /**
+   * SmsLog deleteMany
+   */
+  export type SmsLogDeleteManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Filter which SmsLogs to delete
+     */
+    where?: SmsLogWhereInput
+    /**
+     * Limit how many SmsLogs to delete.
+     */
+    limit?: number
+  }
+
+  /**
+   * SmsLog without action
+   */
+  export type SmsLogDefaultArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the SmsLog
+     */
+    select?: SmsLogSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the SmsLog
+     */
+    omit?: SmsLogOmit<ExtArgs> | null
   }
 
 
@@ -9946,7 +11131,8 @@ export namespace Prisma {
     cognitoId: 'cognitoId',
     name: 'name',
     email: 'email',
-    phoneNumber: 'phoneNumber'
+    phoneNumber: 'phoneNumber',
+    smsOptIn: 'smsOptIn'
   };
 
   export type ManagerScalarFieldEnum = (typeof ManagerScalarFieldEnum)[keyof typeof ManagerScalarFieldEnum]
@@ -9957,10 +11143,25 @@ export namespace Prisma {
     cognitoId: 'cognitoId',
     name: 'name',
     email: 'email',
-    phoneNumber: 'phoneNumber'
+    phoneNumber: 'phoneNumber',
+    smsOptIn: 'smsOptIn'
   };
 
   export type TenantScalarFieldEnum = (typeof TenantScalarFieldEnum)[keyof typeof TenantScalarFieldEnum]
+
+
+  export const SmsLogScalarFieldEnum: {
+    id: 'id',
+    cognitoId: 'cognitoId',
+    userType: 'userType',
+    message: 'message',
+    status: 'status',
+    messageId: 'messageId',
+    error: 'error',
+    createdAt: 'createdAt'
+  };
+
+  export type SmsLogScalarFieldEnum = (typeof SmsLogScalarFieldEnum)[keyof typeof SmsLogScalarFieldEnum]
 
 
   export const LocationScalarFieldEnum: {
@@ -10338,6 +11539,7 @@ export namespace Prisma {
     name?: StringFilter<"Manager"> | string
     email?: StringFilter<"Manager"> | string
     phoneNumber?: StringFilter<"Manager"> | string
+    smsOptIn?: BoolFilter<"Manager"> | boolean
     managedProperties?: PropertyListRelationFilter
   }
 
@@ -10347,6 +11549,7 @@ export namespace Prisma {
     name?: SortOrder
     email?: SortOrder
     phoneNumber?: SortOrder
+    smsOptIn?: SortOrder
     managedProperties?: PropertyOrderByRelationAggregateInput
   }
 
@@ -10359,6 +11562,7 @@ export namespace Prisma {
     name?: StringFilter<"Manager"> | string
     email?: StringFilter<"Manager"> | string
     phoneNumber?: StringFilter<"Manager"> | string
+    smsOptIn?: BoolFilter<"Manager"> | boolean
     managedProperties?: PropertyListRelationFilter
   }, "id" | "cognitoId">
 
@@ -10368,6 +11572,7 @@ export namespace Prisma {
     name?: SortOrder
     email?: SortOrder
     phoneNumber?: SortOrder
+    smsOptIn?: SortOrder
     _count?: ManagerCountOrderByAggregateInput
     _avg?: ManagerAvgOrderByAggregateInput
     _max?: ManagerMaxOrderByAggregateInput
@@ -10384,6 +11589,7 @@ export namespace Prisma {
     name?: StringWithAggregatesFilter<"Manager"> | string
     email?: StringWithAggregatesFilter<"Manager"> | string
     phoneNumber?: StringWithAggregatesFilter<"Manager"> | string
+    smsOptIn?: BoolWithAggregatesFilter<"Manager"> | boolean
   }
 
   export type TenantWhereInput = {
@@ -10395,6 +11601,7 @@ export namespace Prisma {
     name?: StringFilter<"Tenant"> | string
     email?: StringFilter<"Tenant"> | string
     phoneNumber?: StringFilter<"Tenant"> | string
+    smsOptIn?: BoolFilter<"Tenant"> | boolean
     properties?: PropertyListRelationFilter
     favorites?: PropertyListRelationFilter
     applications?: ApplicationListRelationFilter
@@ -10407,6 +11614,7 @@ export namespace Prisma {
     name?: SortOrder
     email?: SortOrder
     phoneNumber?: SortOrder
+    smsOptIn?: SortOrder
     properties?: PropertyOrderByRelationAggregateInput
     favorites?: PropertyOrderByRelationAggregateInput
     applications?: ApplicationOrderByRelationAggregateInput
@@ -10422,6 +11630,7 @@ export namespace Prisma {
     name?: StringFilter<"Tenant"> | string
     email?: StringFilter<"Tenant"> | string
     phoneNumber?: StringFilter<"Tenant"> | string
+    smsOptIn?: BoolFilter<"Tenant"> | boolean
     properties?: PropertyListRelationFilter
     favorites?: PropertyListRelationFilter
     applications?: ApplicationListRelationFilter
@@ -10434,6 +11643,7 @@ export namespace Prisma {
     name?: SortOrder
     email?: SortOrder
     phoneNumber?: SortOrder
+    smsOptIn?: SortOrder
     _count?: TenantCountOrderByAggregateInput
     _avg?: TenantAvgOrderByAggregateInput
     _max?: TenantMaxOrderByAggregateInput
@@ -10450,6 +11660,76 @@ export namespace Prisma {
     name?: StringWithAggregatesFilter<"Tenant"> | string
     email?: StringWithAggregatesFilter<"Tenant"> | string
     phoneNumber?: StringWithAggregatesFilter<"Tenant"> | string
+    smsOptIn?: BoolWithAggregatesFilter<"Tenant"> | boolean
+  }
+
+  export type SmsLogWhereInput = {
+    AND?: SmsLogWhereInput | SmsLogWhereInput[]
+    OR?: SmsLogWhereInput[]
+    NOT?: SmsLogWhereInput | SmsLogWhereInput[]
+    id?: IntFilter<"SmsLog"> | number
+    cognitoId?: StringFilter<"SmsLog"> | string
+    userType?: StringFilter<"SmsLog"> | string
+    message?: StringFilter<"SmsLog"> | string
+    status?: StringFilter<"SmsLog"> | string
+    messageId?: StringNullableFilter<"SmsLog"> | string | null
+    error?: StringNullableFilter<"SmsLog"> | string | null
+    createdAt?: DateTimeFilter<"SmsLog"> | Date | string
+  }
+
+  export type SmsLogOrderByWithRelationInput = {
+    id?: SortOrder
+    cognitoId?: SortOrder
+    userType?: SortOrder
+    message?: SortOrder
+    status?: SortOrder
+    messageId?: SortOrderInput | SortOrder
+    error?: SortOrderInput | SortOrder
+    createdAt?: SortOrder
+  }
+
+  export type SmsLogWhereUniqueInput = Prisma.AtLeast<{
+    id?: number
+    AND?: SmsLogWhereInput | SmsLogWhereInput[]
+    OR?: SmsLogWhereInput[]
+    NOT?: SmsLogWhereInput | SmsLogWhereInput[]
+    cognitoId?: StringFilter<"SmsLog"> | string
+    userType?: StringFilter<"SmsLog"> | string
+    message?: StringFilter<"SmsLog"> | string
+    status?: StringFilter<"SmsLog"> | string
+    messageId?: StringNullableFilter<"SmsLog"> | string | null
+    error?: StringNullableFilter<"SmsLog"> | string | null
+    createdAt?: DateTimeFilter<"SmsLog"> | Date | string
+  }, "id">
+
+  export type SmsLogOrderByWithAggregationInput = {
+    id?: SortOrder
+    cognitoId?: SortOrder
+    userType?: SortOrder
+    message?: SortOrder
+    status?: SortOrder
+    messageId?: SortOrderInput | SortOrder
+    error?: SortOrderInput | SortOrder
+    createdAt?: SortOrder
+    _count?: SmsLogCountOrderByAggregateInput
+    _avg?: SmsLogAvgOrderByAggregateInput
+    _max?: SmsLogMaxOrderByAggregateInput
+    _min?: SmsLogMinOrderByAggregateInput
+    _sum?: SmsLogSumOrderByAggregateInput
+  }
+
+  export type SmsLogScalarWhereWithAggregatesInput = {
+    AND?: SmsLogScalarWhereWithAggregatesInput | SmsLogScalarWhereWithAggregatesInput[]
+    OR?: SmsLogScalarWhereWithAggregatesInput[]
+    NOT?: SmsLogScalarWhereWithAggregatesInput | SmsLogScalarWhereWithAggregatesInput[]
+    id?: IntWithAggregatesFilter<"SmsLog"> | number
+    cognitoId?: StringWithAggregatesFilter<"SmsLog"> | string
+    userType?: StringWithAggregatesFilter<"SmsLog"> | string
+    message?: StringWithAggregatesFilter<"SmsLog"> | string
+    status?: StringWithAggregatesFilter<"SmsLog"> | string
+    messageId?: StringNullableWithAggregatesFilter<"SmsLog"> | string | null
+    error?: StringNullableWithAggregatesFilter<"SmsLog"> | string | null
+    createdAt?: DateTimeWithAggregatesFilter<"SmsLog"> | Date | string
   }
 
   export type LocationWhereInput = {
@@ -10922,6 +12202,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     managedProperties?: PropertyCreateNestedManyWithoutManagerInput
   }
 
@@ -10931,6 +12212,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     managedProperties?: PropertyUncheckedCreateNestedManyWithoutManagerInput
   }
 
@@ -10939,6 +12221,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     managedProperties?: PropertyUpdateManyWithoutManagerNestedInput
   }
 
@@ -10948,6 +12231,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     managedProperties?: PropertyUncheckedUpdateManyWithoutManagerNestedInput
   }
 
@@ -10957,6 +12241,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
   }
 
   export type ManagerUpdateManyMutationInput = {
@@ -10964,6 +12249,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type ManagerUncheckedUpdateManyInput = {
@@ -10972,6 +12258,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type TenantCreateInput = {
@@ -10979,6 +12266,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     properties?: PropertyCreateNestedManyWithoutTenantsInput
     favorites?: PropertyCreateNestedManyWithoutFavoritedByInput
     applications?: ApplicationCreateNestedManyWithoutTenantInput
@@ -10991,6 +12279,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     properties?: PropertyUncheckedCreateNestedManyWithoutTenantsInput
     favorites?: PropertyUncheckedCreateNestedManyWithoutFavoritedByInput
     applications?: ApplicationUncheckedCreateNestedManyWithoutTenantInput
@@ -11002,6 +12291,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     properties?: PropertyUpdateManyWithoutTenantsNestedInput
     favorites?: PropertyUpdateManyWithoutFavoritedByNestedInput
     applications?: ApplicationUpdateManyWithoutTenantNestedInput
@@ -11014,6 +12304,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     properties?: PropertyUncheckedUpdateManyWithoutTenantsNestedInput
     favorites?: PropertyUncheckedUpdateManyWithoutFavoritedByNestedInput
     applications?: ApplicationUncheckedUpdateManyWithoutTenantNestedInput
@@ -11026,6 +12317,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
   }
 
   export type TenantUpdateManyMutationInput = {
@@ -11033,6 +12325,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type TenantUncheckedUpdateManyInput = {
@@ -11041,6 +12334,81 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
+  }
+
+  export type SmsLogCreateInput = {
+    cognitoId: string
+    userType: string
+    message: string
+    status: string
+    messageId?: string | null
+    error?: string | null
+    createdAt?: Date | string
+  }
+
+  export type SmsLogUncheckedCreateInput = {
+    id?: number
+    cognitoId: string
+    userType: string
+    message: string
+    status: string
+    messageId?: string | null
+    error?: string | null
+    createdAt?: Date | string
+  }
+
+  export type SmsLogUpdateInput = {
+    cognitoId?: StringFieldUpdateOperationsInput | string
+    userType?: StringFieldUpdateOperationsInput | string
+    message?: StringFieldUpdateOperationsInput | string
+    status?: StringFieldUpdateOperationsInput | string
+    messageId?: NullableStringFieldUpdateOperationsInput | string | null
+    error?: NullableStringFieldUpdateOperationsInput | string | null
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type SmsLogUncheckedUpdateInput = {
+    id?: IntFieldUpdateOperationsInput | number
+    cognitoId?: StringFieldUpdateOperationsInput | string
+    userType?: StringFieldUpdateOperationsInput | string
+    message?: StringFieldUpdateOperationsInput | string
+    status?: StringFieldUpdateOperationsInput | string
+    messageId?: NullableStringFieldUpdateOperationsInput | string | null
+    error?: NullableStringFieldUpdateOperationsInput | string | null
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type SmsLogCreateManyInput = {
+    id?: number
+    cognitoId: string
+    userType: string
+    message: string
+    status: string
+    messageId?: string | null
+    error?: string | null
+    createdAt?: Date | string
+  }
+
+  export type SmsLogUpdateManyMutationInput = {
+    cognitoId?: StringFieldUpdateOperationsInput | string
+    userType?: StringFieldUpdateOperationsInput | string
+    message?: StringFieldUpdateOperationsInput | string
+    status?: StringFieldUpdateOperationsInput | string
+    messageId?: NullableStringFieldUpdateOperationsInput | string | null
+    error?: NullableStringFieldUpdateOperationsInput | string | null
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type SmsLogUncheckedUpdateManyInput = {
+    id?: IntFieldUpdateOperationsInput | number
+    cognitoId?: StringFieldUpdateOperationsInput | string
+    userType?: StringFieldUpdateOperationsInput | string
+    message?: StringFieldUpdateOperationsInput | string
+    status?: StringFieldUpdateOperationsInput | string
+    messageId?: NullableStringFieldUpdateOperationsInput | string | null
+    error?: NullableStringFieldUpdateOperationsInput | string | null
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
   }
 
   export type LocationUpdateInput = {
@@ -11673,6 +13041,7 @@ export namespace Prisma {
     name?: SortOrder
     email?: SortOrder
     phoneNumber?: SortOrder
+    smsOptIn?: SortOrder
   }
 
   export type ManagerAvgOrderByAggregateInput = {
@@ -11685,6 +13054,7 @@ export namespace Prisma {
     name?: SortOrder
     email?: SortOrder
     phoneNumber?: SortOrder
+    smsOptIn?: SortOrder
   }
 
   export type ManagerMinOrderByAggregateInput = {
@@ -11693,6 +13063,7 @@ export namespace Prisma {
     name?: SortOrder
     email?: SortOrder
     phoneNumber?: SortOrder
+    smsOptIn?: SortOrder
   }
 
   export type ManagerSumOrderByAggregateInput = {
@@ -11705,6 +13076,7 @@ export namespace Prisma {
     name?: SortOrder
     email?: SortOrder
     phoneNumber?: SortOrder
+    smsOptIn?: SortOrder
   }
 
   export type TenantAvgOrderByAggregateInput = {
@@ -11717,6 +13089,7 @@ export namespace Prisma {
     name?: SortOrder
     email?: SortOrder
     phoneNumber?: SortOrder
+    smsOptIn?: SortOrder
   }
 
   export type TenantMinOrderByAggregateInput = {
@@ -11725,10 +13098,85 @@ export namespace Prisma {
     name?: SortOrder
     email?: SortOrder
     phoneNumber?: SortOrder
+    smsOptIn?: SortOrder
   }
 
   export type TenantSumOrderByAggregateInput = {
     id?: SortOrder
+  }
+
+  export type StringNullableFilter<$PrismaModel = never> = {
+    equals?: string | StringFieldRefInput<$PrismaModel> | null
+    in?: string[] | ListStringFieldRefInput<$PrismaModel> | null
+    notIn?: string[] | ListStringFieldRefInput<$PrismaModel> | null
+    lt?: string | StringFieldRefInput<$PrismaModel>
+    lte?: string | StringFieldRefInput<$PrismaModel>
+    gt?: string | StringFieldRefInput<$PrismaModel>
+    gte?: string | StringFieldRefInput<$PrismaModel>
+    contains?: string | StringFieldRefInput<$PrismaModel>
+    startsWith?: string | StringFieldRefInput<$PrismaModel>
+    endsWith?: string | StringFieldRefInput<$PrismaModel>
+    mode?: QueryMode
+    not?: NestedStringNullableFilter<$PrismaModel> | string | null
+  }
+
+  export type SmsLogCountOrderByAggregateInput = {
+    id?: SortOrder
+    cognitoId?: SortOrder
+    userType?: SortOrder
+    message?: SortOrder
+    status?: SortOrder
+    messageId?: SortOrder
+    error?: SortOrder
+    createdAt?: SortOrder
+  }
+
+  export type SmsLogAvgOrderByAggregateInput = {
+    id?: SortOrder
+  }
+
+  export type SmsLogMaxOrderByAggregateInput = {
+    id?: SortOrder
+    cognitoId?: SortOrder
+    userType?: SortOrder
+    message?: SortOrder
+    status?: SortOrder
+    messageId?: SortOrder
+    error?: SortOrder
+    createdAt?: SortOrder
+  }
+
+  export type SmsLogMinOrderByAggregateInput = {
+    id?: SortOrder
+    cognitoId?: SortOrder
+    userType?: SortOrder
+    message?: SortOrder
+    status?: SortOrder
+    messageId?: SortOrder
+    error?: SortOrder
+    createdAt?: SortOrder
+  }
+
+  export type SmsLogSumOrderByAggregateInput = {
+    id?: SortOrder
+  }
+
+  export type StringNullableWithAggregatesFilter<$PrismaModel = never> = {
+    equals?: string | StringFieldRefInput<$PrismaModel> | null
+    in?: string[] | ListStringFieldRefInput<$PrismaModel> | null
+    notIn?: string[] | ListStringFieldRefInput<$PrismaModel> | null
+    lt?: string | StringFieldRefInput<$PrismaModel>
+    lte?: string | StringFieldRefInput<$PrismaModel>
+    gt?: string | StringFieldRefInput<$PrismaModel>
+    gte?: string | StringFieldRefInput<$PrismaModel>
+    contains?: string | StringFieldRefInput<$PrismaModel>
+    startsWith?: string | StringFieldRefInput<$PrismaModel>
+    endsWith?: string | StringFieldRefInput<$PrismaModel>
+    mode?: QueryMode
+    not?: NestedStringNullableWithAggregatesFilter<$PrismaModel> | string | null
+    _count?: NestedIntNullableFilter<$PrismaModel>
+    _min?: NestedStringNullableFilter<$PrismaModel>
+    _max?: NestedStringNullableFilter<$PrismaModel>
   }
 
   export type LocationCountOrderByAggregateInput = {
@@ -11771,21 +13219,6 @@ export namespace Prisma {
     in?: $Enums.ApplicationStatus[] | ListEnumApplicationStatusFieldRefInput<$PrismaModel>
     notIn?: $Enums.ApplicationStatus[] | ListEnumApplicationStatusFieldRefInput<$PrismaModel>
     not?: NestedEnumApplicationStatusFilter<$PrismaModel> | $Enums.ApplicationStatus
-  }
-
-  export type StringNullableFilter<$PrismaModel = never> = {
-    equals?: string | StringFieldRefInput<$PrismaModel> | null
-    in?: string[] | ListStringFieldRefInput<$PrismaModel> | null
-    notIn?: string[] | ListStringFieldRefInput<$PrismaModel> | null
-    lt?: string | StringFieldRefInput<$PrismaModel>
-    lte?: string | StringFieldRefInput<$PrismaModel>
-    gt?: string | StringFieldRefInput<$PrismaModel>
-    gte?: string | StringFieldRefInput<$PrismaModel>
-    contains?: string | StringFieldRefInput<$PrismaModel>
-    startsWith?: string | StringFieldRefInput<$PrismaModel>
-    endsWith?: string | StringFieldRefInput<$PrismaModel>
-    mode?: QueryMode
-    not?: NestedStringNullableFilter<$PrismaModel> | string | null
   }
 
   export type PropertyScalarRelationFilter = {
@@ -11862,24 +13295,6 @@ export namespace Prisma {
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedEnumApplicationStatusFilter<$PrismaModel>
     _max?: NestedEnumApplicationStatusFilter<$PrismaModel>
-  }
-
-  export type StringNullableWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: string | StringFieldRefInput<$PrismaModel> | null
-    in?: string[] | ListStringFieldRefInput<$PrismaModel> | null
-    notIn?: string[] | ListStringFieldRefInput<$PrismaModel> | null
-    lt?: string | StringFieldRefInput<$PrismaModel>
-    lte?: string | StringFieldRefInput<$PrismaModel>
-    gt?: string | StringFieldRefInput<$PrismaModel>
-    gte?: string | StringFieldRefInput<$PrismaModel>
-    contains?: string | StringFieldRefInput<$PrismaModel>
-    startsWith?: string | StringFieldRefInput<$PrismaModel>
-    endsWith?: string | StringFieldRefInput<$PrismaModel>
-    mode?: QueryMode
-    not?: NestedStringNullableWithAggregatesFilter<$PrismaModel> | string | null
-    _count?: NestedIntNullableFilter<$PrismaModel>
-    _min?: NestedStringNullableFilter<$PrismaModel>
-    _max?: NestedStringNullableFilter<$PrismaModel>
   }
 
   export type ApplicationNullableScalarRelationFilter = {
@@ -12467,6 +13882,10 @@ export namespace Prisma {
     deleteMany?: LeaseScalarWhereInput | LeaseScalarWhereInput[]
   }
 
+  export type NullableStringFieldUpdateOperationsInput = {
+    set?: string | null
+  }
+
   export type PropertyUpdateManyWithoutLocationNestedInput = {
     create?: XOR<PropertyCreateWithoutLocationInput, PropertyUncheckedCreateWithoutLocationInput> | PropertyCreateWithoutLocationInput[] | PropertyUncheckedCreateWithoutLocationInput[]
     connectOrCreate?: PropertyCreateOrConnectWithoutLocationInput | PropertyCreateOrConnectWithoutLocationInput[]
@@ -12515,10 +13934,6 @@ export namespace Prisma {
 
   export type EnumApplicationStatusFieldUpdateOperationsInput = {
     set?: $Enums.ApplicationStatus
-  }
-
-  export type NullableStringFieldUpdateOperationsInput = {
-    set?: string | null
   }
 
   export type PropertyUpdateOneRequiredWithoutApplicationsNestedInput = {
@@ -12861,13 +14276,6 @@ export namespace Prisma {
     _max?: NestedIntNullableFilter<$PrismaModel>
   }
 
-  export type NestedEnumApplicationStatusFilter<$PrismaModel = never> = {
-    equals?: $Enums.ApplicationStatus | EnumApplicationStatusFieldRefInput<$PrismaModel>
-    in?: $Enums.ApplicationStatus[] | ListEnumApplicationStatusFieldRefInput<$PrismaModel>
-    notIn?: $Enums.ApplicationStatus[] | ListEnumApplicationStatusFieldRefInput<$PrismaModel>
-    not?: NestedEnumApplicationStatusFilter<$PrismaModel> | $Enums.ApplicationStatus
-  }
-
   export type NestedStringNullableFilter<$PrismaModel = never> = {
     equals?: string | StringFieldRefInput<$PrismaModel> | null
     in?: string[] | ListStringFieldRefInput<$PrismaModel> | null
@@ -12880,16 +14288,6 @@ export namespace Prisma {
     startsWith?: string | StringFieldRefInput<$PrismaModel>
     endsWith?: string | StringFieldRefInput<$PrismaModel>
     not?: NestedStringNullableFilter<$PrismaModel> | string | null
-  }
-
-  export type NestedEnumApplicationStatusWithAggregatesFilter<$PrismaModel = never> = {
-    equals?: $Enums.ApplicationStatus | EnumApplicationStatusFieldRefInput<$PrismaModel>
-    in?: $Enums.ApplicationStatus[] | ListEnumApplicationStatusFieldRefInput<$PrismaModel>
-    notIn?: $Enums.ApplicationStatus[] | ListEnumApplicationStatusFieldRefInput<$PrismaModel>
-    not?: NestedEnumApplicationStatusWithAggregatesFilter<$PrismaModel> | $Enums.ApplicationStatus
-    _count?: NestedIntFilter<$PrismaModel>
-    _min?: NestedEnumApplicationStatusFilter<$PrismaModel>
-    _max?: NestedEnumApplicationStatusFilter<$PrismaModel>
   }
 
   export type NestedStringNullableWithAggregatesFilter<$PrismaModel = never> = {
@@ -12907,6 +14305,23 @@ export namespace Prisma {
     _count?: NestedIntNullableFilter<$PrismaModel>
     _min?: NestedStringNullableFilter<$PrismaModel>
     _max?: NestedStringNullableFilter<$PrismaModel>
+  }
+
+  export type NestedEnumApplicationStatusFilter<$PrismaModel = never> = {
+    equals?: $Enums.ApplicationStatus | EnumApplicationStatusFieldRefInput<$PrismaModel>
+    in?: $Enums.ApplicationStatus[] | ListEnumApplicationStatusFieldRefInput<$PrismaModel>
+    notIn?: $Enums.ApplicationStatus[] | ListEnumApplicationStatusFieldRefInput<$PrismaModel>
+    not?: NestedEnumApplicationStatusFilter<$PrismaModel> | $Enums.ApplicationStatus
+  }
+
+  export type NestedEnumApplicationStatusWithAggregatesFilter<$PrismaModel = never> = {
+    equals?: $Enums.ApplicationStatus | EnumApplicationStatusFieldRefInput<$PrismaModel>
+    in?: $Enums.ApplicationStatus[] | ListEnumApplicationStatusFieldRefInput<$PrismaModel>
+    notIn?: $Enums.ApplicationStatus[] | ListEnumApplicationStatusFieldRefInput<$PrismaModel>
+    not?: NestedEnumApplicationStatusWithAggregatesFilter<$PrismaModel> | $Enums.ApplicationStatus
+    _count?: NestedIntFilter<$PrismaModel>
+    _min?: NestedEnumApplicationStatusFilter<$PrismaModel>
+    _max?: NestedEnumApplicationStatusFilter<$PrismaModel>
   }
 
   export type NestedEnumPaymentStatusFilter<$PrismaModel = never> = {
@@ -12931,6 +14346,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
   }
 
   export type ManagerUncheckedCreateWithoutManagedPropertiesInput = {
@@ -12939,6 +14355,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
   }
 
   export type ManagerCreateOrConnectWithoutManagedPropertiesInput = {
@@ -13015,6 +14432,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     properties?: PropertyCreateNestedManyWithoutTenantsInput
     applications?: ApplicationCreateNestedManyWithoutTenantInput
     leases?: LeaseCreateNestedManyWithoutTenantInput
@@ -13026,6 +14444,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     properties?: PropertyUncheckedCreateNestedManyWithoutTenantsInput
     applications?: ApplicationUncheckedCreateNestedManyWithoutTenantInput
     leases?: LeaseUncheckedCreateNestedManyWithoutTenantInput
@@ -13041,6 +14460,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     favorites?: PropertyCreateNestedManyWithoutFavoritedByInput
     applications?: ApplicationCreateNestedManyWithoutTenantInput
     leases?: LeaseCreateNestedManyWithoutTenantInput
@@ -13052,6 +14472,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     favorites?: PropertyUncheckedCreateNestedManyWithoutFavoritedByInput
     applications?: ApplicationUncheckedCreateNestedManyWithoutTenantInput
     leases?: LeaseUncheckedCreateNestedManyWithoutTenantInput
@@ -13100,6 +14521,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type ManagerUncheckedUpdateWithoutManagedPropertiesInput = {
@@ -13108,6 +14530,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type LeaseUpsertWithWhereUniqueWithoutPropertyInput = {
@@ -13196,6 +14619,7 @@ export namespace Prisma {
     name?: StringFilter<"Tenant"> | string
     email?: StringFilter<"Tenant"> | string
     phoneNumber?: StringFilter<"Tenant"> | string
+    smsOptIn?: BoolFilter<"Tenant"> | boolean
   }
 
   export type TenantUpsertWithWhereUniqueWithoutPropertiesInput = {
@@ -13695,6 +15119,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     properties?: PropertyCreateNestedManyWithoutTenantsInput
     favorites?: PropertyCreateNestedManyWithoutFavoritedByInput
     leases?: LeaseCreateNestedManyWithoutTenantInput
@@ -13706,6 +15131,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     properties?: PropertyUncheckedCreateNestedManyWithoutTenantsInput
     favorites?: PropertyUncheckedCreateNestedManyWithoutFavoritedByInput
     leases?: LeaseUncheckedCreateNestedManyWithoutTenantInput
@@ -13820,6 +15246,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     properties?: PropertyUpdateManyWithoutTenantsNestedInput
     favorites?: PropertyUpdateManyWithoutFavoritedByNestedInput
     leases?: LeaseUpdateManyWithoutTenantNestedInput
@@ -13831,6 +15258,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     properties?: PropertyUncheckedUpdateManyWithoutTenantsNestedInput
     favorites?: PropertyUncheckedUpdateManyWithoutFavoritedByNestedInput
     leases?: LeaseUncheckedUpdateManyWithoutTenantNestedInput
@@ -13929,6 +15357,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     properties?: PropertyCreateNestedManyWithoutTenantsInput
     favorites?: PropertyCreateNestedManyWithoutFavoritedByInput
     applications?: ApplicationCreateNestedManyWithoutTenantInput
@@ -13940,6 +15369,7 @@ export namespace Prisma {
     name: string
     email: string
     phoneNumber: string
+    smsOptIn?: boolean
     properties?: PropertyUncheckedCreateNestedManyWithoutTenantsInput
     favorites?: PropertyUncheckedCreateNestedManyWithoutFavoritedByInput
     applications?: ApplicationUncheckedCreateNestedManyWithoutTenantInput
@@ -14083,6 +15513,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     properties?: PropertyUpdateManyWithoutTenantsNestedInput
     favorites?: PropertyUpdateManyWithoutFavoritedByNestedInput
     applications?: ApplicationUpdateManyWithoutTenantNestedInput
@@ -14094,6 +15525,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     properties?: PropertyUncheckedUpdateManyWithoutTenantsNestedInput
     favorites?: PropertyUncheckedUpdateManyWithoutFavoritedByNestedInput
     applications?: ApplicationUncheckedUpdateManyWithoutTenantNestedInput
@@ -14311,6 +15743,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     properties?: PropertyUpdateManyWithoutTenantsNestedInput
     applications?: ApplicationUpdateManyWithoutTenantNestedInput
     leases?: LeaseUpdateManyWithoutTenantNestedInput
@@ -14322,6 +15755,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     properties?: PropertyUncheckedUpdateManyWithoutTenantsNestedInput
     applications?: ApplicationUncheckedUpdateManyWithoutTenantNestedInput
     leases?: LeaseUncheckedUpdateManyWithoutTenantNestedInput
@@ -14333,6 +15767,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type TenantUpdateWithoutPropertiesInput = {
@@ -14340,6 +15775,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     favorites?: PropertyUpdateManyWithoutFavoritedByNestedInput
     applications?: ApplicationUpdateManyWithoutTenantNestedInput
     leases?: LeaseUpdateManyWithoutTenantNestedInput
@@ -14351,6 +15787,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
     favorites?: PropertyUncheckedUpdateManyWithoutFavoritedByNestedInput
     applications?: ApplicationUncheckedUpdateManyWithoutTenantNestedInput
     leases?: LeaseUncheckedUpdateManyWithoutTenantNestedInput
@@ -14362,6 +15799,7 @@ export namespace Prisma {
     name?: StringFieldUpdateOperationsInput | string
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
+    smsOptIn?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type PropertyCreateManyManagerInput = {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.740.0",
+        "@aws-sdk/client-sns": "^3.740.0",
         "@aws-sdk/lib-storage": "^3.740.0",
         "@prisma/client": "^6.3.0",
         "@terraformer/wkt": "^2.2.1",
@@ -309,6 +310,522 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.873.0.tgz",
+      "integrity": "sha512-NuAkmtMozX1I9biFNfyGazm91lbfbmZfF43SW32lJLmEyAV/1acn2MubTh91SjmnLGqxfgc9jrplX9b/M8Mnyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/credential-provider-node": "3.873.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.873.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.873.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.873.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.873.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.8.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-retry": "^4.1.19",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.26",
+        "@smithy/util-defaults-mode-node": "^4.0.26",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.873.0.tgz",
+      "integrity": "sha512-EmcrOgFODWe7IsLKFTeSXM9TlQ80/BO1MBISlr7w2ydnOaUYIiPGRRJnDpeIgMaNqT4Rr2cRN2RiMrbFO7gDdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.873.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.873.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.873.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.873.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.8.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-retry": "^4.1.19",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.26",
+        "@smithy/util-defaults-mode-node": "^4.0.26",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/core": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.873.0.tgz",
+      "integrity": "sha512-WrROjp8X1VvmnZ4TBzwM7RF+EB3wRaY9kQJLXw+Aes0/3zRjUXvGIlseobGJMqMEGnM0YekD2F87UaVfot1xeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/xml-builder": "3.873.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.873.0.tgz",
+      "integrity": "sha512-FWj1yUs45VjCADv80JlGshAttUHBL2xtTAbJcAxkkJZzLRKVkdyrepFWhv/95MvDyzfbT6PgJiWMdW65l/8ooA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.873.0.tgz",
+      "integrity": "sha512-0sIokBlXIsndjZFUfr3Xui8W6kPC4DAeBGAXxGi9qbFZ9PWJjn1vt2COLikKH3q2snchk+AsznREZG8NW6ezSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-stream": "^4.2.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.873.0.tgz",
+      "integrity": "sha512-bQdGqh47Sk0+2S3C+N46aNQsZFzcHs7ndxYLARH/avYXf02Nl68p194eYFaAHJSQ1re5IbExU1+pbums7FJ9fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/credential-provider-env": "3.873.0",
+        "@aws-sdk/credential-provider-http": "3.873.0",
+        "@aws-sdk/credential-provider-process": "3.873.0",
+        "@aws-sdk/credential-provider-sso": "3.873.0",
+        "@aws-sdk/credential-provider-web-identity": "3.873.0",
+        "@aws-sdk/nested-clients": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.873.0.tgz",
+      "integrity": "sha512-+v/xBEB02k2ExnSDL8+1gD6UizY4Q/HaIJkNSkitFynRiiTQpVOSkCkA0iWxzksMeN8k1IHTE5gzeWpkEjNwbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.873.0",
+        "@aws-sdk/credential-provider-http": "3.873.0",
+        "@aws-sdk/credential-provider-ini": "3.873.0",
+        "@aws-sdk/credential-provider-process": "3.873.0",
+        "@aws-sdk/credential-provider-sso": "3.873.0",
+        "@aws-sdk/credential-provider-web-identity": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.873.0.tgz",
+      "integrity": "sha512-ycFv9WN+UJF7bK/ElBq1ugWA4NMbYS//1K55bPQZb2XUpAM2TWFlEjG7DIyOhLNTdl6+CbHlCdhlKQuDGgmm0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.873.0.tgz",
+      "integrity": "sha512-SudkAOZmjEEYgUrqlUUjvrtbWJeI54/0Xo87KRxm4kfBtMqSx0TxbplNUAk8Gkg4XQNY0o7jpG8tK7r2Wc2+uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.873.0",
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/token-providers": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.873.0.tgz",
+      "integrity": "sha512-Gw2H21+VkA6AgwKkBtTtlGZ45qgyRZPSKWs0kUwXVlmGOiPz61t/lBX0vG6I06ZIz2wqeTJ5OA1pWZLqw1j0JQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/nested-clients": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.873.0.tgz",
+      "integrity": "sha512-KZ/W1uruWtMOs7D5j3KquOxzCnV79KQW9MjJFZM/M0l6KI8J6V3718MXxFHsTjUE4fpdV6SeCNLV1lwGygsjJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.873.0.tgz",
+      "integrity": "sha512-QhNZ8X7pW68kFez9QxUSN65Um0Feo18ZmHxszQZNUhKDsXew/EG9NPQE/HgYcekcon35zHxC4xs+FeNuPurP2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.873.0.tgz",
+      "integrity": "sha512-OtgY8EXOzRdEWR//WfPkA/fXl0+WwE8hq0y9iw2caNyKPtca85dzrrZWnPqyBK/cpImosrpR1iKMYr41XshsCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.873.0.tgz",
+      "integrity": "sha512-gHqAMYpWkPhZLwqB3Yj83JKdL2Vsb64sryo8LN2UdpElpS+0fT4yjqSxKTfp7gkhN6TCIxF24HQgbPk5FMYJWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.873.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.873.0.tgz",
+      "integrity": "sha512-yg8JkRHuH/xO65rtmLOWcd9XQhxX1kAonp2CliXT44eA/23OBds6XoheY44eZeHfCTgutDLTYitvy3k9fQY6ZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.873.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.873.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.873.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.873.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.8.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-retry": "^4.1.19",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.26",
+        "@smithy/util-defaults-mode-node": "^4.0.26",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.873.0.tgz",
+      "integrity": "sha512-q9sPoef+BBG6PJnc4x60vK/bfVwvRWsPgcoQyIra057S/QGjq5VkjvNk6H8xedf6vnKlXNBwq9BaANBXnldUJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/token-providers": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.873.0.tgz",
+      "integrity": "sha512-BWOCeFeV/Ba8fVhtwUw/0Hz4wMm9fjXnMb4Z2a5he/jFlz5mt1/rr6IQ4MyKgzOaz24YrvqsJW2a0VUKOaYDvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/nested-clients": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/types": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+      "integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.873.0.tgz",
+      "integrity": "sha512-YByHrhjxYdjKRf/RQygRK1uh0As1FIi9+jXTcIEX/rBgN8mUByczr2u4QXBzw7ZdbdcOBMOkPnLRjNOWW1MkFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-endpoints": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.873.0.tgz",
+      "integrity": "sha512-AcRdbK6o19yehEcywI43blIBhOCSo6UgyWcuOJX5CFF8k39xm1ILCjQlRRjchLAxWrm0lU0Q7XV90RiMMFMZtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.873.0.tgz",
+      "integrity": "sha512-9MivTP+q9Sis71UxuBaIY3h5jxH0vN3/ZWGxO8ADL19S2OIfknrYSAfzE5fpoKROVBu0bS4VifHOFq4PY1zsxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
+      "integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.734.0",
@@ -1039,12 +1556,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.5.tgz",
+      "integrity": "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1077,15 +1594,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
-      "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
+      "integrity": "sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-middleware": "^4.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1093,34 +1610,56 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.2.tgz",
-      "integrity": "sha512-htwQXkbdF13uwwDevz9BEzL5ABK+1sJpVQXywwGSH973AVOvisHNfpcB8A8761G6XgHoS2kHPqc9DqHJ2gp+/Q==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.8.0.tgz",
+      "integrity": "sha512-EYqsIYJmkR1VhVE9pccnk353xhs+lB6btdutJEtsp7R055haMJp2yE16eSxw8fv+G0WUY6vqxyYOP8kOqawxYQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-stream": "^4.0.2",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-stream": "^4.2.4",
         "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/core/node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT"
+    },
+    "node_modules/@smithy/core/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
-      "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.7.tgz",
+      "integrity": "sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1198,14 +1737,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-      "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
+      "integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/querystring-builder": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-base64": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -1229,12 +1768,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
-      "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.5.tgz",
+      "integrity": "sha512-cv1HHkKhpyRb6ahD8Vcfb2Hgz67vNIXEp2vnhzfxLFGRukLCNEA5QdsorbUEzXma1Rco0u3rx5VTqbM06GcZqQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
@@ -1258,12 +1797,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
-      "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.5.tgz",
+      "integrity": "sha512-IVnb78Qtf7EJpoEVo7qJ8BEXQwgC4n3igeJNNKEj/MLYtapnx8A67Zt/J3RXAj2xSO1910zk0LdFiygSemuLow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1297,13 +1836,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
-      "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.5.tgz",
+      "integrity": "sha512-l1jlNZoYzoCC7p0zCtBDE5OBXZ95yMKlRlftooE5jPWQn4YBPLgsp+oeHp7iMHaTGoUdFqmHOPa8c9G3gBsRpQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1311,18 +1850,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.3.tgz",
-      "integrity": "sha512-YdbmWhQF5kIxZjWqPIgboVfi8i5XgiYMM7GGKFMTvBei4XjNQfNv8sukT50ITvgnWKKKpOtp0C0h7qixLgb77Q==",
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.18.tgz",
+      "integrity": "sha512-ZhvqcVRPZxnZlokcPaTwb+r+h4yOIOCJmx0v2d1bpVlmP465g3qpVSf7wxcq5zZdu4jb0H4yIMxuPwDJSQc3MQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.1.2",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/core": "^3.8.0",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-middleware": "^4.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1330,24 +1869,31 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.4.tgz",
-      "integrity": "sha512-wmxyUBGHaYUqul0wZiset4M39SMtDBOtUr2KpDuftKNN74Do9Y36Go6Eqzj9tL0mIPpr31ulB5UUtxcsCeGXsQ==",
+      "version": "4.1.19",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.19.tgz",
+      "integrity": "sha512-X58zx/NVECjeuUB6A8HBu4bhx72EoUz+T5jTMIyeNKx2lf+Gs9TmWPNNkH+5QF0COjpInP/xSpJGJ7xEnAklQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/service-error-classification": "^4.0.1",
-        "@smithy/smithy-client": "^4.1.3",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/service-error-classification": "^4.0.7",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@types/uuid": "^9.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT"
     },
     "node_modules/@smithy/middleware-retry/node_modules/uuid": {
       "version": "9.0.1",
@@ -1363,12 +1909,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
-      "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
+      "integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1376,12 +1923,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-      "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
+      "integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1389,14 +1936,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-      "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
+      "integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1404,15 +1951,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.2.tgz",
-      "integrity": "sha512-X66H9aah9hisLLSnGuzRYba6vckuFtGE+a5DcHLliI/YlqKrGoxhisD5XbX44KyoeRzoNlGr94eTsMVHFAzPOw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.1.tgz",
+      "integrity": "sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/abort-controller": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/querystring-builder": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1420,12 +1967,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-      "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
+      "integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1433,12 +1980,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-      "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+      "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1446,12 +1993,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-      "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+      "integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-uri-escape": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -1460,12 +2007,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-      "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
+      "integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1473,24 +2020,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
-      "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.7.tgz",
+      "integrity": "sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0"
+        "@smithy/types": "^4.3.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-      "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
+      "integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1498,16 +2045,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-      "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
+      "integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-middleware": "^4.0.5",
         "@smithy/util-uri-escape": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
@@ -1517,17 +2064,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.3.tgz",
-      "integrity": "sha512-A2Hz85pu8BJJaYFdX8yb1yocqigyqBzn+OVaVgm+Kwi/DkN8vhN2kbDVEfADo6jXf5hPKquMLGA3UINA64UZ7A==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.10.tgz",
+      "integrity": "sha512-iW6HjXqN0oPtRS0NK/zzZ4zZeGESIFcxj2FkWed3mcK8jdSdHzvnCKXSjvewESKAgGKAbJRA+OsaqKhkdYRbQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.1.2",
-        "@smithy/middleware-endpoint": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-stream": "^4.0.2",
+        "@smithy/core": "^3.8.0",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-stream": "^4.2.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1535,9 +2082,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+      "integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1547,13 +2094,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-      "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
+      "integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/querystring-parser": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1624,14 +2171,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.4.tgz",
-      "integrity": "sha512-Ej1bV5sbrIfH++KnWxjjzFNq9nyP3RIUq2c9Iqq7SmMO/idUR24sqvKH2LUQFTSPy/K7G4sB2m8n7YYlEAfZaw==",
+      "version": "4.0.26",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.26.tgz",
+      "integrity": "sha512-xgl75aHIS/3rrGp7iTxQAOELYeyiwBu+eEgAk4xfKwJJ0L8VUjhO2shsDpeil54BOFsqmk5xfdesiewbUY5tKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/smithy-client": "^4.1.3",
-        "@smithy/types": "^4.1.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -1640,17 +2187,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.4.tgz",
-      "integrity": "sha512-HE1I7gxa6yP7ZgXPCFfZSDmVmMtY7SHqzFF55gM/GPegzZKaQWZZ+nYn9C2Cc3JltCMyWe63VPR3tSFDEvuGjw==",
+      "version": "4.0.26",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.26.tgz",
+      "integrity": "sha512-z81yyIkGiLLYVDetKTUeCZQ8x20EEzvQjrqJtb/mXnevLq2+w3XCEWTJ2pMp401b6BkEkHVfXb/cROBpVauLMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/smithy-client": "^4.1.3",
-        "@smithy/types": "^4.1.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1658,13 +2205,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
-      "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.7.tgz",
+      "integrity": "sha512-klGBP+RpBp6V5JbrY2C/VKnHXn3d5V2YrifZbmMY8os7M6m8wdYFoO6w/fe5VkP+YVwrEktW3IWYaSQVNZJ8oQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1684,12 +2231,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-      "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
+      "integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1697,13 +2244,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
-      "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.7.tgz",
+      "integrity": "sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/service-error-classification": "^4.0.7",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1711,14 +2258,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.0.2.tgz",
-      "integrity": "sha512-0eZ4G5fRzIoewtHtwaYyl8g2C+osYOT4KClXgfdNEDAgkbe2TYPqcnw4GAWabqkZCax2ihRGPe9LZnsPdIUIHA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
+      "integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/types": "^4.1.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-hex-encoding": "^4.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
   "description": "",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.740.0",
+    "@aws-sdk/client-sns": "^3.740.0",
     "@aws-sdk/lib-storage": "^3.740.0",
     "@prisma/client": "^6.3.0",
     "@terraformer/wkt": "^2.2.1",

--- a/server/prisma/migrations/20250206000000_add_sms_preferences/migration.sql
+++ b/server/prisma/migrations/20250206000000_add_sms_preferences/migration.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "Manager" ADD COLUMN "smsOptIn" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Tenant" ADD COLUMN "smsOptIn" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE TABLE "SmsLog" (
+    "id" SERIAL PRIMARY KEY,
+    "cognitoId" TEXT NOT NULL,
+    "userType" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "messageId" TEXT,
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -101,6 +101,7 @@ model Manager {
   name        String
   email       String
   phoneNumber String
+  smsOptIn    Boolean @default(false)
 
   managedProperties Property[]
 }
@@ -111,11 +112,23 @@ model Tenant {
   name        String
   email       String
   phoneNumber String
+  smsOptIn    Boolean @default(false)
 
   properties   Property[]    @relation("TenantProperties")
   favorites    Property[]    @relation("TenantFavorites")
   applications Application[]
   leases       Lease[]
+}
+
+model SmsLog {
+  id         Int      @id @default(autoincrement())
+  cognitoId  String
+  userType   String
+  message    String
+  status     String
+  messageId  String?
+  error      String?
+  createdAt  DateTime @default(now())
 }
 
 model Location {

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -31,7 +31,7 @@ export const createManager = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId, name, email, phoneNumber } = req.body;
+    const { cognitoId, name, email, phoneNumber, smsOptIn } = req.body;
 
     const manager = await prisma.manager.create({
       data: {
@@ -39,6 +39,7 @@ export const createManager = async (
         name,
         email,
         phoneNumber,
+        smsOptIn,
       },
     });
 
@@ -56,7 +57,7 @@ export const updateManager = async (
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
-    const { name, email, phoneNumber } = req.body;
+    const { name, email, phoneNumber, smsOptIn } = req.body;
 
     const updateManager = await prisma.manager.update({
       where: { cognitoId },
@@ -64,6 +65,7 @@ export const updateManager = async (
         name,
         email,
         phoneNumber,
+        smsOptIn,
       },
     });
 

--- a/server/src/controllers/smsController.ts
+++ b/server/src/controllers/smsController.ts
@@ -1,0 +1,12 @@
+import { Request, Response } from "express";
+import { sendSMS } from "../services/smsService";
+
+export const sendSms = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { cognitoId, userType, message } = req.body;
+    const result = await sendSMS({ cognitoId, userType, message });
+    res.json(result);
+  } catch (err: any) {
+    res.status(500).json({ message: `Failed to send SMS: ${err.message}` });
+  }
+};

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -31,7 +31,7 @@ export const createTenant = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId, name, email, phoneNumber } = req.body;
+    const { cognitoId, name, email, phoneNumber, smsOptIn } = req.body;
 
     const tenant = await prisma.tenant.create({
       data: {
@@ -39,6 +39,7 @@ export const createTenant = async (
         name,
         email,
         phoneNumber,
+        smsOptIn,
       },
     });
 
@@ -56,7 +57,7 @@ export const updateTenant = async (
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
-    const { name, email, phoneNumber } = req.body;
+    const { name, email, phoneNumber, smsOptIn } = req.body;
 
     const updateTenant = await prisma.tenant.update({
       where: { cognitoId },
@@ -64,6 +65,7 @@ export const updateTenant = async (
         name,
         email,
         phoneNumber,
+        smsOptIn,
       },
     });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import managerRoutes from "./routes/managerRoutes";
 import propertyRoutes from "./routes/propertyRoutes";
 import leaseRoutes from "./routes/leaseRoutes";
 import applicationRoutes from "./routes/applicationRoutes";
+import smsRoutes from "./routes/smsRoutes";
 
 /* CONFIGURATIONS */
 dotenv.config();
@@ -33,6 +34,7 @@ app.use("/properties", propertyRoutes);
 app.use("/leases", leaseRoutes);
 app.use("/tenants", authMiddleware(["tenant"]), tenantRoutes);
 app.use("/managers", authMiddleware(["manager"]), managerRoutes);
+app.use("/sms", authMiddleware(["tenant", "manager"]), smsRoutes);
 
 /* SERVER */
 const port = Number(process.env.PORT) || 3002;

--- a/server/src/routes/smsRoutes.ts
+++ b/server/src/routes/smsRoutes.ts
@@ -1,0 +1,8 @@
+import express from "express";
+import { sendSms } from "../controllers/smsController";
+
+const router = express.Router();
+
+router.post("/", sendSms);
+
+export default router;

--- a/server/src/services/smsService.ts
+++ b/server/src/services/smsService.ts
@@ -1,0 +1,64 @@
+import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const snsClient = new SNSClient({ region: process.env.AWS_REGION });
+
+interface SendSMSParams {
+  cognitoId: string;
+  userType: "tenant" | "manager";
+  message: string;
+}
+
+export async function sendSMS({ cognitoId, userType, message }: SendSMSParams) {
+  const user =
+    userType === "tenant"
+      ? await prisma.tenant.findUnique({ where: { cognitoId } })
+      : await prisma.manager.findUnique({ where: { cognitoId } });
+
+  if (!user) {
+    throw new Error("User not found");
+  }
+
+  if (!user.smsOptIn) {
+    await prisma.smsLog.create({
+      data: {
+        cognitoId,
+        userType,
+        message,
+        status: "opt-out",
+      },
+    });
+    return { status: "opt-out" };
+  }
+
+  try {
+    const result = await snsClient.send(
+      new PublishCommand({ Message: message, PhoneNumber: user.phoneNumber })
+    );
+
+    await prisma.smsLog.create({
+      data: {
+        cognitoId,
+        userType,
+        message,
+        status: "sent",
+        messageId: result.MessageId,
+      },
+    });
+
+    return { status: "sent", messageId: result.MessageId };
+  } catch (err: any) {
+    await prisma.smsLog.create({
+      data: {
+        cognitoId,
+        userType,
+        message,
+        status: "error",
+        error: err.message,
+      },
+    });
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- store SMS opt-in preferences for managers and tenants
- integrate AWS SNS service that logs delivery results
- expose `/sms` endpoint to send messages respecting opt-in/out

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a97d9abf7483288450cd0f99c9fe7a