### PR TITLE
feat: add tenant dashboard with aggregated data

### DIFF
--- a/client/src/app/(dashboard)/layout.tsx
+++ b/client/src/app/(dashboard)/layout.tsx
@@ -24,7 +24,7 @@ const DashboardLayout = ({ children }: { children: React.ReactNode }) => {
         router.push(
           userRole === "manager"
             ? "/managers/properties"
-            : "/tenants/favorites",
+            : "/tenants",
           { scroll: false }
         );
       } else {

--- a/client/src/app/(dashboard)/tenants/messages/page.tsx
+++ b/client/src/app/(dashboard)/tenants/messages/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import Header from "@/components/Header";
+
+const MessagesPage = () => {
+  return (
+    <div className="dashboard-container">
+      <Header title="Messages" subtitle="View your conversations" />
+      <p>No messages yet.</p>
+    </div>
+  );
+};
+
+export default MessagesPage;

--- a/client/src/app/(dashboard)/tenants/page.tsx
+++ b/client/src/app/(dashboard)/tenants/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Header from "@/components/Header";
+import Loading from "@/components/Loading";
+import {
+  useGetAuthUserQuery,
+  useGetTenantDashboardQuery,
+} from "@/state/api";
+import Link from "next/link";
+import {
+  Heart,
+  FileText,
+  Calendar,
+  MessageSquare,
+} from "lucide-react";
+
+const TenantDashboard = () => {
+  const { data: authUser } = useGetAuthUserQuery();
+  const { data, isLoading, error } = useGetTenantDashboardQuery(
+    authUser?.cognitoInfo?.userId || "",
+    { skip: !authUser?.cognitoInfo?.userId }
+  );
+
+  if (isLoading) return <Loading />;
+  if (error) return <div>Error loading dashboard</div>;
+
+  const items = [
+    {
+      href: "/tenants/favorites",
+      icon: Heart,
+      label: "Favorites",
+      count: data?.favorites.length || 0,
+    },
+    {
+      href: "/tenants/applications",
+      icon: FileText,
+      label: "Applications",
+      count: data?.applications.length || 0,
+    },
+    {
+      href: "/tenants/tour-requests",
+      icon: Calendar,
+      label: "Tour Requests",
+      count: data?.tourRequests.length || 0,
+    },
+    {
+      href: "/tenants/messages",
+      icon: MessageSquare,
+      label: "Messages",
+      count: data?.messages.length || 0,
+    },
+  ];
+
+  return (
+    <div className="dashboard-container">
+      <Header title="Dashboard" subtitle="Quick overview of your activity" />
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {items.map(({ href, icon: Icon, label, count }) => (
+          <Link key={href} href={href} className="block">
+            <div className="bg-white rounded-lg shadow p-6 hover:shadow-md transition">
+              <div className="flex items-center justify-between mb-2">
+                <h2 className="text-lg font-semibold">{label}</h2>
+                <Icon className="w-5 h-5 text-primary-600" />
+              </div>
+              <p className="text-2xl font-bold">{count}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TenantDashboard;

--- a/client/src/app/(dashboard)/tenants/tour-requests/page.tsx
+++ b/client/src/app/(dashboard)/tenants/tour-requests/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import Header from "@/components/Header";
+
+const TourRequestsPage = () => {
+  return (
+    <div className="dashboard-container">
+      <Header title="Tour Requests" subtitle="Manage your tour requests" />
+      <p>No tour requests yet.</p>
+    </div>
+  );
+};
+
+export default TourRequestsPage;

--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -11,10 +11,12 @@ import {
 } from "./ui/sidebar";
 import {
   Building,
+  Calendar,
   FileText,
   Heart,
   Home,
   Menu,
+  MessageSquare,
   Settings,
   X,
 } from "lucide-react";
@@ -43,6 +45,16 @@ const AppSidebar = ({ userType }: AppSidebarProps) => {
             icon: FileText,
             label: "Applications",
             href: "/tenants/applications",
+          },
+          {
+            icon: Calendar,
+            label: "Tour Requests",
+            href: "/tenants/tour-requests",
+          },
+          {
+            icon: MessageSquare,
+            label: "Messages",
+            href: "/tenants/messages",
           },
           { icon: Home, label: "Residences", href: "/tenants/residences" },
           { icon: Settings, label: "Settings", href: "/tenants/settings" },

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -129,7 +129,7 @@ const Navbar = () => {
                       router.push(
                         authUser.userRole?.toLowerCase() === "manager"
                           ? "/managers/properties"
-                          : "/tenants/favorites",
+                          : "/tenants",
                         { scroll: false }
                       )
                     }

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -134,6 +134,23 @@ export const api = createApi({
       },
     }),
 
+    getTenantDashboard: build.query<
+      {
+        favorites: Property[];
+        applications: Application[];
+        tourRequests: unknown[];
+        messages: unknown[];
+      },
+      string
+    >({
+      query: (cognitoId) => `tenants/${cognitoId}/dashboard`,
+      async onQueryStarted(_, { queryFulfilled }) {
+        await withToast(queryFulfilled, {
+          error: "Failed to load dashboard data.",
+        });
+      },
+    }),
+
     getCurrentResidences: build.query<Property[], string>({
       query: (cognitoId) => `tenants/${cognitoId}/current-residences`,
       providesTags: (result) =>
@@ -361,6 +378,7 @@ export const {
   useGetManagerPropertiesQuery,
   useCreatePropertyMutation,
   useGetTenantQuery,
+  useGetTenantDashboardQuery,
   useAddFavoritePropertyMutation,
   useRemoveFavoritePropertyMutation,
   useGetLeasesQuery,

--- a/server/src/routes/tenantRoutes.ts
+++ b/server/src/routes/tenantRoutes.ts
@@ -6,6 +6,7 @@ import {
   getCurrentResidences,
   addFavoriteProperty,
   removeFavoriteProperty,
+  getTenantDashboard,
 } from "../controllers/tenantControllers";
 
 const router = express.Router();
@@ -16,5 +17,6 @@ router.post("/", createTenant);
 router.get("/:cognitoId/current-residences", getCurrentResidences);
 router.post("/:cognitoId/favorites/:propertyId", addFavoriteProperty);
 router.delete("/:cognitoId/favorites/:propertyId", removeFavoriteProperty);
+router.get("/:cognitoId/dashboard", getTenantDashboard);
 
 export default router;


### PR DESCRIPTION
## Summary
- add aggregated tenant dashboard endpoint
- build tenant dashboard page for favorites, applications, tour requests, and messages
- add navigation links and placeholder pages for new sections

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm run build` (server)
- `npm test` (client) *(fails: Missing script "test")*
- `NEXT_TELEMETRY_DISABLED=1 npm run lint` (client)


------
https://chatgpt.com/codex/tasks/task_e_68a97d925ae88328a6ed0badcf3d0576