### PR TITLE
Add multi-step application wizard with autosave

### DIFF
--- a/client/src/app/(nondashboard)/search/[id]/ApplicationModal.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/ApplicationModal.tsx
@@ -8,9 +8,15 @@ import {
 } from "@/components/ui/dialog";
 import { Form } from "@/components/ui/form";
 import { ApplicationFormData, applicationSchema } from "@/lib/schemas";
-import { useCreateApplicationMutation, useGetAuthUserQuery } from "@/state/api";
+import {
+  useCreateApplicationMutation,
+  useGetAuthUserQuery,
+  useSaveApplicationDraftMutation,
+  useGetApplicationDraftQuery,
+  useGeneratePresignedUrlMutation,
+} from "@/state/api";
 import { zodResolver } from "@hookform/resolvers/zod";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 const ApplicationModal = ({
@@ -19,7 +25,20 @@ const ApplicationModal = ({
   propertyId,
 }: ApplicationModalProps) => {
   const [createApplication] = useCreateApplicationMutation();
+  const [saveDraft] = useSaveApplicationDraftMutation();
+  const [generatePresignedUrl] = useGeneratePresignedUrlMutation();
   const { data: authUser } = useGetAuthUserQuery();
+  const { data: existingDraft } = useGetApplicationDraftQuery(
+    {
+      propertyId,
+      tenantCognitoId: authUser?.cognitoInfo.userId || "",
+    },
+    { skip: !authUser }
+  );
+
+  const [step, setStep] = useState(1);
+  const [draftId, setDraftId] = useState<number | undefined>();
+  const [documentUrls, setDocumentUrls] = useState<string[]>([]);
 
   const form = useForm<ApplicationFormData>({
     resolver: zodResolver(applicationSchema),
@@ -31,6 +50,51 @@ const ApplicationModal = ({
     },
   });
 
+  useEffect(() => {
+    if (existingDraft) {
+      setDraftId(existingDraft.id);
+      setStep(existingDraft.currentStep);
+      form.reset(existingDraft.data);
+      setDocumentUrls(existingDraft.documentUrls || []);
+    }
+  }, [existingDraft, form]);
+
+  const autosave = async (currentStep: number) => {
+    if (!authUser) return;
+    const payload = {
+      draftId,
+      propertyId,
+      tenantCognitoId: authUser.cognitoInfo.userId,
+      data: form.getValues(),
+      currentStep,
+      documentUrls,
+    };
+    const result = await saveDraft(payload).unwrap();
+    setDraftId(result.id);
+  };
+
+  const handleNext = async () => {
+    const nextStep = step + 1;
+    await autosave(nextStep);
+    setStep(nextStep);
+  };
+
+  const handleFileChange = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    if (!e.target.files) return;
+    const files = Array.from(e.target.files);
+    for (const file of files) {
+      const { url } = await generatePresignedUrl({
+        fileName: file.name,
+        fileType: file.type,
+      }).unwrap();
+      await fetch(url, { method: "PUT", body: file });
+      setDocumentUrls((prev) => [...prev, url.split("?")[0]]);
+    }
+    await autosave(step);
+  };
+
   const onSubmit = async (data: ApplicationFormData) => {
     if (!authUser || authUser.userRole !== "tenant") {
       console.error(
@@ -41,10 +105,12 @@ const ApplicationModal = ({
 
     await createApplication({
       ...data,
+      documentUrls,
       applicationDate: new Date().toISOString(),
       status: "Pending",
       propertyId: propertyId,
       tenantCognitoId: authUser.cognitoInfo.userId,
+      draftId,
     });
     onClose();
   };
@@ -57,33 +123,66 @@ const ApplicationModal = ({
         </DialogHeader>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
-            <CustomFormField
-              name="name"
-              label="Name"
-              type="text"
-              placeholder="Enter your full name"
-            />
-            <CustomFormField
-              name="email"
-              label="Email"
-              type="email"
-              placeholder="Enter your email address"
-            />
-            <CustomFormField
-              name="phoneNumber"
-              label="Phone Number"
-              type="text"
-              placeholder="Enter your phone number"
-            />
-            <CustomFormField
-              name="message"
-              label="Message (Optional)"
-              type="textarea"
-              placeholder="Enter any additional information"
-            />
-            <Button type="submit" className="bg-primary-700 text-white w-full">
-              Submit Application
-            </Button>
+            {step === 1 && (
+              <>
+                <CustomFormField
+                  name="name"
+                  label="Name"
+                  type="text"
+                  placeholder="Enter your full name"
+                />
+                <CustomFormField
+                  name="email"
+                  label="Email"
+                  type="email"
+                  placeholder="Enter your email address"
+                />
+                <CustomFormField
+                  name="phoneNumber"
+                  label="Phone Number"
+                  type="text"
+                  placeholder="Enter your phone number"
+                />
+                <Button
+                  type="button"
+                  onClick={handleNext}
+                  className="bg-primary-700 text-white w-full"
+                >
+                  Next
+                </Button>
+              </>
+            )}
+            {step === 2 && (
+              <>
+                <CustomFormField
+                  name="message"
+                  label="Message (Optional)"
+                  type="textarea"
+                  placeholder="Enter any additional information"
+                />
+                <input type="file" multiple onChange={handleFileChange} />
+                <ul>
+                  {documentUrls.map((url) => (
+                    <li key={url}>{url.split("/").pop()}</li>
+                  ))}
+                </ul>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    onClick={() => setStep(step - 1)}
+                    className="flex-1"
+                  >
+                    Back
+                  </Button>
+                  <Button
+                    type="submit"
+                    className="bg-primary-700 text-white flex-1"
+                  >
+                    Submit Application
+                  </Button>
+                </div>
+              </>
+            )}
           </form>
         </Form>
       </DialogContent>

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -348,6 +348,33 @@ export const api = createApi({
         });
       },
     }),
+
+    getApplicationDraft: build.query<
+      any,
+      { propertyId: number; tenantCognitoId: string }
+    >({
+      query: ({ propertyId, tenantCognitoId }) =>
+        `applications/draft?propertyId=${propertyId}&tenantCognitoId=${tenantCognitoId}`,
+    }),
+
+    saveApplicationDraft: build.mutation<any, any>({
+      query: (body) => ({
+        url: `applications/draft`,
+        method: "POST",
+        body,
+      }),
+    }),
+
+    generatePresignedUrl: build.mutation<
+      { url: string; key: string },
+      { fileName: string; fileType: string }
+    >({
+      query: (body) => ({
+        url: `applications/presigned-url`,
+        method: "POST",
+        body,
+      }),
+    }),
   }),
 });
 
@@ -369,4 +396,7 @@ export const {
   useGetApplicationsQuery,
   useUpdateApplicationStatusMutation,
   useCreateApplicationMutation,
+  useGetApplicationDraftQuery,
+  useSaveApplicationDraftMutation,
+  useGeneratePresignedUrlMutation,
 } = api;

--- a/client/src/types/prismaTypes.d.ts
+++ b/client/src/types/prismaTypes.d.ts
@@ -39,6 +39,11 @@ export type Location = $Result.DefaultSelection<Prisma.$LocationPayload>
  */
 export type Application = $Result.DefaultSelection<Prisma.$ApplicationPayload>
 /**
+ * Model ApplicationDraft
+ * 
+ */
+export type ApplicationDraft = $Result.DefaultSelection<Prisma.$ApplicationDraftPayload>
+/**
  * Model Lease
  * 
  */
@@ -319,6 +324,16 @@ export class PrismaClient<
     * ```
     */
   get application(): Prisma.ApplicationDelegate<ExtArgs, ClientOptions>;
+
+  /**
+   * `prisma.applicationDraft`: Exposes CRUD operations for the **ApplicationDraft** model.
+    * Example usage:
+    * ```ts
+    * // Fetch zero or more ApplicationDrafts
+    * const applicationDrafts = await prisma.applicationDraft.findMany()
+    * ```
+    */
+  get applicationDraft(): Prisma.ApplicationDraftDelegate<ExtArgs, ClientOptions>;
 
   /**
    * `prisma.lease`: Exposes CRUD operations for the **Lease** model.
@@ -784,6 +799,7 @@ export namespace Prisma {
     Tenant: 'Tenant',
     Location: 'Location',
     Application: 'Application',
+    ApplicationDraft: 'ApplicationDraft',
     Lease: 'Lease',
     Payment: 'Payment'
   };
@@ -801,7 +817,7 @@ export namespace Prisma {
 
   export type TypeMap<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, ClientOptions = {}> = {
     meta: {
-      modelProps: "property" | "manager" | "tenant" | "location" | "application" | "lease" | "payment"
+      modelProps: "property" | "manager" | "tenant" | "location" | "application" | "applicationDraft" | "lease" | "payment"
       txIsolationLevel: Prisma.TransactionIsolationLevel
     }
     model: {
@@ -1159,6 +1175,80 @@ export namespace Prisma {
           }
         }
       }
+      ApplicationDraft: {
+        payload: Prisma.$ApplicationDraftPayload<ExtArgs>
+        fields: Prisma.ApplicationDraftFieldRefs
+        operations: {
+          findUnique: {
+            args: Prisma.ApplicationDraftFindUniqueArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$ApplicationDraftPayload> | null
+          }
+          findUniqueOrThrow: {
+            args: Prisma.ApplicationDraftFindUniqueOrThrowArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$ApplicationDraftPayload>
+          }
+          findFirst: {
+            args: Prisma.ApplicationDraftFindFirstArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$ApplicationDraftPayload> | null
+          }
+          findFirstOrThrow: {
+            args: Prisma.ApplicationDraftFindFirstOrThrowArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$ApplicationDraftPayload>
+          }
+          findMany: {
+            args: Prisma.ApplicationDraftFindManyArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$ApplicationDraftPayload>[]
+          }
+          create: {
+            args: Prisma.ApplicationDraftCreateArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$ApplicationDraftPayload>
+          }
+          createMany: {
+            args: Prisma.ApplicationDraftCreateManyArgs<ExtArgs>
+            result: BatchPayload
+          }
+          createManyAndReturn: {
+            args: Prisma.ApplicationDraftCreateManyAndReturnArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$ApplicationDraftPayload>[]
+          }
+          delete: {
+            args: Prisma.ApplicationDraftDeleteArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$ApplicationDraftPayload>
+          }
+          update: {
+            args: Prisma.ApplicationDraftUpdateArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$ApplicationDraftPayload>
+          }
+          deleteMany: {
+            args: Prisma.ApplicationDraftDeleteManyArgs<ExtArgs>
+            result: BatchPayload
+          }
+          updateMany: {
+            args: Prisma.ApplicationDraftUpdateManyArgs<ExtArgs>
+            result: BatchPayload
+          }
+          updateManyAndReturn: {
+            args: Prisma.ApplicationDraftUpdateManyAndReturnArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$ApplicationDraftPayload>[]
+          }
+          upsert: {
+            args: Prisma.ApplicationDraftUpsertArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$ApplicationDraftPayload>
+          }
+          aggregate: {
+            args: Prisma.ApplicationDraftAggregateArgs<ExtArgs>
+            result: $Utils.Optional<AggregateApplicationDraft>
+          }
+          groupBy: {
+            args: Prisma.ApplicationDraftGroupByArgs<ExtArgs>
+            result: $Utils.Optional<ApplicationDraftGroupByOutputType>[]
+          }
+          count: {
+            args: Prisma.ApplicationDraftCountArgs<ExtArgs>
+            result: $Utils.Optional<ApplicationDraftCountAggregateOutputType> | number
+          }
+        }
+      }
       Lease: {
         payload: Prisma.$LeasePayload<ExtArgs>
         fields: Prisma.LeaseFieldRefs
@@ -1396,6 +1486,7 @@ export namespace Prisma {
     tenant?: TenantOmit
     location?: LocationOmit
     application?: ApplicationOmit
+    applicationDraft?: ApplicationDraftOmit
     lease?: LeaseOmit
     payment?: PaymentOmit
   }
@@ -6441,6 +6532,7 @@ export namespace Prisma {
     phoneNumber: number
     message: number
     leaseId: number
+    documentUrls: number
     _all: number
   }
 
@@ -6494,6 +6586,7 @@ export namespace Prisma {
     phoneNumber?: true
     message?: true
     leaseId?: true
+    documentUrls?: true
     _all?: true
   }
 
@@ -6594,6 +6687,7 @@ export namespace Prisma {
     phoneNumber: string
     message: string | null
     leaseId: number | null
+    documentUrls: string[]
     _count: ApplicationCountAggregateOutputType | null
     _avg: ApplicationAvgAggregateOutputType | null
     _sum: ApplicationSumAggregateOutputType | null
@@ -6626,6 +6720,7 @@ export namespace Prisma {
     phoneNumber?: boolean
     message?: boolean
     leaseId?: boolean
+    documentUrls?: boolean
     property?: boolean | PropertyDefaultArgs<ExtArgs>
     tenant?: boolean | TenantDefaultArgs<ExtArgs>
     lease?: boolean | Application$leaseArgs<ExtArgs>
@@ -6642,6 +6737,7 @@ export namespace Prisma {
     phoneNumber?: boolean
     message?: boolean
     leaseId?: boolean
+    documentUrls?: boolean
     property?: boolean | PropertyDefaultArgs<ExtArgs>
     tenant?: boolean | TenantDefaultArgs<ExtArgs>
     lease?: boolean | Application$leaseArgs<ExtArgs>
@@ -6658,6 +6754,7 @@ export namespace Prisma {
     phoneNumber?: boolean
     message?: boolean
     leaseId?: boolean
+    documentUrls?: boolean
     property?: boolean | PropertyDefaultArgs<ExtArgs>
     tenant?: boolean | TenantDefaultArgs<ExtArgs>
     lease?: boolean | Application$leaseArgs<ExtArgs>
@@ -6674,9 +6771,10 @@ export namespace Prisma {
     phoneNumber?: boolean
     message?: boolean
     leaseId?: boolean
+    documentUrls?: boolean
   }
 
-  export type ApplicationOmit<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetOmit<"id" | "applicationDate" | "status" | "propertyId" | "tenantCognitoId" | "name" | "email" | "phoneNumber" | "message" | "leaseId", ExtArgs["result"]["application"]>
+  export type ApplicationOmit<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetOmit<"id" | "applicationDate" | "status" | "propertyId" | "tenantCognitoId" | "name" | "email" | "phoneNumber" | "message" | "leaseId" | "documentUrls", ExtArgs["result"]["application"]>
   export type ApplicationInclude<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
     property?: boolean | PropertyDefaultArgs<ExtArgs>
     tenant?: boolean | TenantDefaultArgs<ExtArgs>
@@ -6711,6 +6809,7 @@ export namespace Prisma {
       phoneNumber: string
       message: string | null
       leaseId: number | null
+      documentUrls: string[]
     }, ExtArgs["result"]["application"]>
     composites: {}
   }
@@ -7147,6 +7246,7 @@ export namespace Prisma {
     readonly phoneNumber: FieldRef<"Application", 'String'>
     readonly message: FieldRef<"Application", 'String'>
     readonly leaseId: FieldRef<"Application", 'Int'>
+    readonly documentUrls: FieldRef<"Application", 'String[]'>
   }
     
 
@@ -7577,6 +7677,1074 @@ export namespace Prisma {
      * Choose, which related nodes to fetch as well
      */
     include?: ApplicationInclude<ExtArgs> | null
+  }
+
+
+  /**
+   * Model ApplicationDraft
+   */
+
+  export type AggregateApplicationDraft = {
+    _count: ApplicationDraftCountAggregateOutputType | null
+    _avg: ApplicationDraftAvgAggregateOutputType | null
+    _sum: ApplicationDraftSumAggregateOutputType | null
+    _min: ApplicationDraftMinAggregateOutputType | null
+    _max: ApplicationDraftMaxAggregateOutputType | null
+  }
+
+  export type ApplicationDraftAvgAggregateOutputType = {
+    id: number | null
+    propertyId: number | null
+    currentStep: number | null
+  }
+
+  export type ApplicationDraftSumAggregateOutputType = {
+    id: number | null
+    propertyId: number | null
+    currentStep: number | null
+  }
+
+  export type ApplicationDraftMinAggregateOutputType = {
+    id: number | null
+    propertyId: number | null
+    tenantCognitoId: string | null
+    currentStep: number | null
+    createdAt: Date | null
+    updatedAt: Date | null
+  }
+
+  export type ApplicationDraftMaxAggregateOutputType = {
+    id: number | null
+    propertyId: number | null
+    tenantCognitoId: string | null
+    currentStep: number | null
+    createdAt: Date | null
+    updatedAt: Date | null
+  }
+
+  export type ApplicationDraftCountAggregateOutputType = {
+    id: number
+    propertyId: number
+    tenantCognitoId: number
+    data: number
+    currentStep: number
+    documentUrls: number
+    createdAt: number
+    updatedAt: number
+    _all: number
+  }
+
+
+  export type ApplicationDraftAvgAggregateInputType = {
+    id?: true
+    propertyId?: true
+    currentStep?: true
+  }
+
+  export type ApplicationDraftSumAggregateInputType = {
+    id?: true
+    propertyId?: true
+    currentStep?: true
+  }
+
+  export type ApplicationDraftMinAggregateInputType = {
+    id?: true
+    propertyId?: true
+    tenantCognitoId?: true
+    currentStep?: true
+    createdAt?: true
+    updatedAt?: true
+  }
+
+  export type ApplicationDraftMaxAggregateInputType = {
+    id?: true
+    propertyId?: true
+    tenantCognitoId?: true
+    currentStep?: true
+    createdAt?: true
+    updatedAt?: true
+  }
+
+  export type ApplicationDraftCountAggregateInputType = {
+    id?: true
+    propertyId?: true
+    tenantCognitoId?: true
+    data?: true
+    currentStep?: true
+    documentUrls?: true
+    createdAt?: true
+    updatedAt?: true
+    _all?: true
+  }
+
+  export type ApplicationDraftAggregateArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Filter which ApplicationDraft to aggregate.
+     */
+    where?: ApplicationDraftWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ApplicationDrafts to fetch.
+     */
+    orderBy?: ApplicationDraftOrderByWithRelationInput | ApplicationDraftOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     */
+    cursor?: ApplicationDraftWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` ApplicationDrafts from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` ApplicationDrafts.
+     */
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned ApplicationDrafts
+    **/
+    _count?: true | ApplicationDraftCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to average
+    **/
+    _avg?: ApplicationDraftAvgAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to sum
+    **/
+    _sum?: ApplicationDraftSumAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: ApplicationDraftMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: ApplicationDraftMaxAggregateInputType
+  }
+
+  export type GetApplicationDraftAggregateType<T extends ApplicationDraftAggregateArgs> = {
+        [P in keyof T & keyof AggregateApplicationDraft]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateApplicationDraft[P]>
+      : GetScalarType<T[P], AggregateApplicationDraft[P]>
+  }
+
+
+
+
+  export type ApplicationDraftGroupByArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    where?: ApplicationDraftWhereInput
+    orderBy?: ApplicationDraftOrderByWithAggregationInput | ApplicationDraftOrderByWithAggregationInput[]
+    by: ApplicationDraftScalarFieldEnum[] | ApplicationDraftScalarFieldEnum
+    having?: ApplicationDraftScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: ApplicationDraftCountAggregateInputType | true
+    _avg?: ApplicationDraftAvgAggregateInputType
+    _sum?: ApplicationDraftSumAggregateInputType
+    _min?: ApplicationDraftMinAggregateInputType
+    _max?: ApplicationDraftMaxAggregateInputType
+  }
+
+  export type ApplicationDraftGroupByOutputType = {
+    id: number
+    propertyId: number
+    tenantCognitoId: string
+    data: JsonValue
+    currentStep: number
+    documentUrls: string[]
+    createdAt: Date
+    updatedAt: Date
+    _count: ApplicationDraftCountAggregateOutputType | null
+    _avg: ApplicationDraftAvgAggregateOutputType | null
+    _sum: ApplicationDraftSumAggregateOutputType | null
+    _min: ApplicationDraftMinAggregateOutputType | null
+    _max: ApplicationDraftMaxAggregateOutputType | null
+  }
+
+  type GetApplicationDraftGroupByPayload<T extends ApplicationDraftGroupByArgs> = Prisma.PrismaPromise<
+    Array<
+      PickEnumerable<ApplicationDraftGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof ApplicationDraftGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], ApplicationDraftGroupByOutputType[P]>
+            : GetScalarType<T[P], ApplicationDraftGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type ApplicationDraftSelect<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
+    id?: boolean
+    propertyId?: boolean
+    tenantCognitoId?: boolean
+    data?: boolean
+    currentStep?: boolean
+    documentUrls?: boolean
+    createdAt?: boolean
+    updatedAt?: boolean
+  }, ExtArgs["result"]["applicationDraft"]>
+
+  export type ApplicationDraftSelectCreateManyAndReturn<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
+    id?: boolean
+    propertyId?: boolean
+    tenantCognitoId?: boolean
+    data?: boolean
+    currentStep?: boolean
+    documentUrls?: boolean
+    createdAt?: boolean
+    updatedAt?: boolean
+  }, ExtArgs["result"]["applicationDraft"]>
+
+  export type ApplicationDraftSelectUpdateManyAndReturn<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
+    id?: boolean
+    propertyId?: boolean
+    tenantCognitoId?: boolean
+    data?: boolean
+    currentStep?: boolean
+    documentUrls?: boolean
+    createdAt?: boolean
+    updatedAt?: boolean
+  }, ExtArgs["result"]["applicationDraft"]>
+
+  export type ApplicationDraftSelectScalar = {
+    id?: boolean
+    propertyId?: boolean
+    tenantCognitoId?: boolean
+    data?: boolean
+    currentStep?: boolean
+    documentUrls?: boolean
+    createdAt?: boolean
+    updatedAt?: boolean
+  }
+
+  export type ApplicationDraftOmit<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetOmit<"id" | "propertyId" | "tenantCognitoId" | "data" | "currentStep" | "documentUrls" | "createdAt" | "updatedAt", ExtArgs["result"]["applicationDraft"]>
+
+  export type $ApplicationDraftPayload<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    name: "ApplicationDraft"
+    objects: {}
+    scalars: $Extensions.GetPayloadResult<{
+      id: number
+      propertyId: number
+      tenantCognitoId: string
+      data: Prisma.JsonValue
+      currentStep: number
+      documentUrls: string[]
+      createdAt: Date
+      updatedAt: Date
+    }, ExtArgs["result"]["applicationDraft"]>
+    composites: {}
+  }
+
+  type ApplicationDraftGetPayload<S extends boolean | null | undefined | ApplicationDraftDefaultArgs> = $Result.GetResult<Prisma.$ApplicationDraftPayload, S>
+
+  type ApplicationDraftCountArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> =
+    Omit<ApplicationDraftFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
+      select?: ApplicationDraftCountAggregateInputType | true
+    }
+
+  export interface ApplicationDraftDelegate<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, ClientOptions = {}> {
+    [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['model']['ApplicationDraft'], meta: { name: 'ApplicationDraft' } }
+    /**
+     * Find zero or one ApplicationDraft that matches the filter.
+     * @param {ApplicationDraftFindUniqueArgs} args - Arguments to find a ApplicationDraft
+     * @example
+     * // Get one ApplicationDraft
+     * const applicationDraft = await prisma.applicationDraft.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findUnique<T extends ApplicationDraftFindUniqueArgs>(args: SelectSubset<T, ApplicationDraftFindUniqueArgs<ExtArgs>>): Prisma__ApplicationDraftClient<$Result.GetResult<Prisma.$ApplicationDraftPayload<ExtArgs>, T, "findUnique", ClientOptions> | null, null, ExtArgs, ClientOptions>
+
+    /**
+     * Find one ApplicationDraft that matches the filter or throw an error with `error.code='P2025'`
+     * if no matches were found.
+     * @param {ApplicationDraftFindUniqueOrThrowArgs} args - Arguments to find a ApplicationDraft
+     * @example
+     * // Get one ApplicationDraft
+     * const applicationDraft = await prisma.applicationDraft.findUniqueOrThrow({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findUniqueOrThrow<T extends ApplicationDraftFindUniqueOrThrowArgs>(args: SelectSubset<T, ApplicationDraftFindUniqueOrThrowArgs<ExtArgs>>): Prisma__ApplicationDraftClient<$Result.GetResult<Prisma.$ApplicationDraftPayload<ExtArgs>, T, "findUniqueOrThrow", ClientOptions>, never, ExtArgs, ClientOptions>
+
+    /**
+     * Find the first ApplicationDraft that matches the filter.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ApplicationDraftFindFirstArgs} args - Arguments to find a ApplicationDraft
+     * @example
+     * // Get one ApplicationDraft
+     * const applicationDraft = await prisma.applicationDraft.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findFirst<T extends ApplicationDraftFindFirstArgs>(args?: SelectSubset<T, ApplicationDraftFindFirstArgs<ExtArgs>>): Prisma__ApplicationDraftClient<$Result.GetResult<Prisma.$ApplicationDraftPayload<ExtArgs>, T, "findFirst", ClientOptions> | null, null, ExtArgs, ClientOptions>
+
+    /**
+     * Find the first ApplicationDraft that matches the filter or
+     * throw `PrismaKnownClientError` with `P2025` code if no matches were found.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ApplicationDraftFindFirstOrThrowArgs} args - Arguments to find a ApplicationDraft
+     * @example
+     * // Get one ApplicationDraft
+     * const applicationDraft = await prisma.applicationDraft.findFirstOrThrow({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findFirstOrThrow<T extends ApplicationDraftFindFirstOrThrowArgs>(args?: SelectSubset<T, ApplicationDraftFindFirstOrThrowArgs<ExtArgs>>): Prisma__ApplicationDraftClient<$Result.GetResult<Prisma.$ApplicationDraftPayload<ExtArgs>, T, "findFirstOrThrow", ClientOptions>, never, ExtArgs, ClientOptions>
+
+    /**
+     * Find zero or more ApplicationDrafts that matches the filter.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ApplicationDraftFindManyArgs} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all ApplicationDrafts
+     * const applicationDrafts = await prisma.applicationDraft.findMany()
+     * 
+     * // Get first 10 ApplicationDrafts
+     * const applicationDrafts = await prisma.applicationDraft.findMany({ take: 10 })
+     * 
+     * // Only select the `id`
+     * const applicationDraftWithIdOnly = await prisma.applicationDraft.findMany({ select: { id: true } })
+     * 
+     */
+    findMany<T extends ApplicationDraftFindManyArgs>(args?: SelectSubset<T, ApplicationDraftFindManyArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$ApplicationDraftPayload<ExtArgs>, T, "findMany", ClientOptions>>
+
+    /**
+     * Create a ApplicationDraft.
+     * @param {ApplicationDraftCreateArgs} args - Arguments to create a ApplicationDraft.
+     * @example
+     * // Create one ApplicationDraft
+     * const ApplicationDraft = await prisma.applicationDraft.create({
+     *   data: {
+     *     // ... data to create a ApplicationDraft
+     *   }
+     * })
+     * 
+     */
+    create<T extends ApplicationDraftCreateArgs>(args: SelectSubset<T, ApplicationDraftCreateArgs<ExtArgs>>): Prisma__ApplicationDraftClient<$Result.GetResult<Prisma.$ApplicationDraftPayload<ExtArgs>, T, "create", ClientOptions>, never, ExtArgs, ClientOptions>
+
+    /**
+     * Create many ApplicationDrafts.
+     * @param {ApplicationDraftCreateManyArgs} args - Arguments to create many ApplicationDrafts.
+     * @example
+     * // Create many ApplicationDrafts
+     * const applicationDraft = await prisma.applicationDraft.createMany({
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *     
+     */
+    createMany<T extends ApplicationDraftCreateManyArgs>(args?: SelectSubset<T, ApplicationDraftCreateManyArgs<ExtArgs>>): Prisma.PrismaPromise<BatchPayload>
+
+    /**
+     * Create many ApplicationDrafts and returns the data saved in the database.
+     * @param {ApplicationDraftCreateManyAndReturnArgs} args - Arguments to create many ApplicationDrafts.
+     * @example
+     * // Create many ApplicationDrafts
+     * const applicationDraft = await prisma.applicationDraft.createManyAndReturn({
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * 
+     * // Create many ApplicationDrafts and only return the `id`
+     * const applicationDraftWithIdOnly = await prisma.applicationDraft.createManyAndReturn({
+     *   select: { id: true },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * 
+     */
+    createManyAndReturn<T extends ApplicationDraftCreateManyAndReturnArgs>(args?: SelectSubset<T, ApplicationDraftCreateManyAndReturnArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$ApplicationDraftPayload<ExtArgs>, T, "createManyAndReturn", ClientOptions>>
+
+    /**
+     * Delete a ApplicationDraft.
+     * @param {ApplicationDraftDeleteArgs} args - Arguments to delete one ApplicationDraft.
+     * @example
+     * // Delete one ApplicationDraft
+     * const ApplicationDraft = await prisma.applicationDraft.delete({
+     *   where: {
+     *     // ... filter to delete one ApplicationDraft
+     *   }
+     * })
+     * 
+     */
+    delete<T extends ApplicationDraftDeleteArgs>(args: SelectSubset<T, ApplicationDraftDeleteArgs<ExtArgs>>): Prisma__ApplicationDraftClient<$Result.GetResult<Prisma.$ApplicationDraftPayload<ExtArgs>, T, "delete", ClientOptions>, never, ExtArgs, ClientOptions>
+
+    /**
+     * Update one ApplicationDraft.
+     * @param {ApplicationDraftUpdateArgs} args - Arguments to update one ApplicationDraft.
+     * @example
+     * // Update one ApplicationDraft
+     * const applicationDraft = await prisma.applicationDraft.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+     */
+    update<T extends ApplicationDraftUpdateArgs>(args: SelectSubset<T, ApplicationDraftUpdateArgs<ExtArgs>>): Prisma__ApplicationDraftClient<$Result.GetResult<Prisma.$ApplicationDraftPayload<ExtArgs>, T, "update", ClientOptions>, never, ExtArgs, ClientOptions>
+
+    /**
+     * Delete zero or more ApplicationDrafts.
+     * @param {ApplicationDraftDeleteManyArgs} args - Arguments to filter ApplicationDrafts to delete.
+     * @example
+     * // Delete a few ApplicationDrafts
+     * const { count } = await prisma.applicationDraft.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+     */
+    deleteMany<T extends ApplicationDraftDeleteManyArgs>(args?: SelectSubset<T, ApplicationDraftDeleteManyArgs<ExtArgs>>): Prisma.PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more ApplicationDrafts.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ApplicationDraftUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many ApplicationDrafts
+     * const applicationDraft = await prisma.applicationDraft.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+     */
+    updateMany<T extends ApplicationDraftUpdateManyArgs>(args: SelectSubset<T, ApplicationDraftUpdateManyArgs<ExtArgs>>): Prisma.PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more ApplicationDrafts and returns the data updated in the database.
+     * @param {ApplicationDraftUpdateManyAndReturnArgs} args - Arguments to update many ApplicationDrafts.
+     * @example
+     * // Update many ApplicationDrafts
+     * const applicationDraft = await prisma.applicationDraft.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * 
+     * // Update zero or more ApplicationDrafts and only return the `id`
+     * const applicationDraftWithIdOnly = await prisma.applicationDraft.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * 
+     */
+    updateManyAndReturn<T extends ApplicationDraftUpdateManyAndReturnArgs>(args: SelectSubset<T, ApplicationDraftUpdateManyAndReturnArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$ApplicationDraftPayload<ExtArgs>, T, "updateManyAndReturn", ClientOptions>>
+
+    /**
+     * Create or update one ApplicationDraft.
+     * @param {ApplicationDraftUpsertArgs} args - Arguments to update or create a ApplicationDraft.
+     * @example
+     * // Update or create a ApplicationDraft
+     * const applicationDraft = await prisma.applicationDraft.upsert({
+     *   create: {
+     *     // ... data to create a ApplicationDraft
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the ApplicationDraft we want to update
+     *   }
+     * })
+     */
+    upsert<T extends ApplicationDraftUpsertArgs>(args: SelectSubset<T, ApplicationDraftUpsertArgs<ExtArgs>>): Prisma__ApplicationDraftClient<$Result.GetResult<Prisma.$ApplicationDraftPayload<ExtArgs>, T, "upsert", ClientOptions>, never, ExtArgs, ClientOptions>
+
+
+    /**
+     * Count the number of ApplicationDrafts.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ApplicationDraftCountArgs} args - Arguments to filter ApplicationDrafts to count.
+     * @example
+     * // Count the number of ApplicationDrafts
+     * const count = await prisma.applicationDraft.count({
+     *   where: {
+     *     // ... the filter for the ApplicationDrafts we want to count
+     *   }
+     * })
+    **/
+    count<T extends ApplicationDraftCountArgs>(
+      args?: Subset<T, ApplicationDraftCountArgs>,
+    ): Prisma.PrismaPromise<
+      T extends $Utils.Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], ApplicationDraftCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a ApplicationDraft.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ApplicationDraftAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends ApplicationDraftAggregateArgs>(args: Subset<T, ApplicationDraftAggregateArgs>): Prisma.PrismaPromise<GetApplicationDraftAggregateType<T>>
+
+    /**
+     * Group by ApplicationDraft.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {ApplicationDraftGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends ApplicationDraftGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: ApplicationDraftGroupByArgs['orderBy'] }
+        : { orderBy?: ApplicationDraftGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? `Error: "by" must not be empty.`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? `Error: Field "${P}" used in "having" needs to be provided in "by".`
+            : [
+                Error,
+                'Field ',
+                P,
+                ` in "having" needs to be provided in "by"`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, ApplicationDraftGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetApplicationDraftGroupByPayload<T> : Prisma.PrismaPromise<InputErrors>
+  /**
+   * Fields of the ApplicationDraft model
+   */
+  readonly fields: ApplicationDraftFieldRefs;
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for ApplicationDraft.
+   * Why is this prefixed with `Prisma__`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export interface Prisma__ApplicationDraftClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, ClientOptions = {}> extends Prisma.PrismaPromise<T> {
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
+  }
+
+
+
+
+  /**
+   * Fields of the ApplicationDraft model
+   */ 
+  interface ApplicationDraftFieldRefs {
+    readonly id: FieldRef<"ApplicationDraft", 'Int'>
+    readonly propertyId: FieldRef<"ApplicationDraft", 'Int'>
+    readonly tenantCognitoId: FieldRef<"ApplicationDraft", 'String'>
+    readonly data: FieldRef<"ApplicationDraft", 'Json'>
+    readonly currentStep: FieldRef<"ApplicationDraft", 'Int'>
+    readonly documentUrls: FieldRef<"ApplicationDraft", 'String[]'>
+    readonly createdAt: FieldRef<"ApplicationDraft", 'DateTime'>
+    readonly updatedAt: FieldRef<"ApplicationDraft", 'DateTime'>
+  }
+    
+
+  // Custom InputTypes
+  /**
+   * ApplicationDraft findUnique
+   */
+  export type ApplicationDraftFindUniqueArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
+    /**
+     * Filter, which ApplicationDraft to fetch.
+     */
+    where: ApplicationDraftWhereUniqueInput
+  }
+
+  /**
+   * ApplicationDraft findUniqueOrThrow
+   */
+  export type ApplicationDraftFindUniqueOrThrowArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
+    /**
+     * Filter, which ApplicationDraft to fetch.
+     */
+    where: ApplicationDraftWhereUniqueInput
+  }
+
+  /**
+   * ApplicationDraft findFirst
+   */
+  export type ApplicationDraftFindFirstArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
+    /**
+     * Filter, which ApplicationDraft to fetch.
+     */
+    where?: ApplicationDraftWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ApplicationDrafts to fetch.
+     */
+    orderBy?: ApplicationDraftOrderByWithRelationInput | ApplicationDraftOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for ApplicationDrafts.
+     */
+    cursor?: ApplicationDraftWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` ApplicationDrafts from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` ApplicationDrafts.
+     */
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of ApplicationDrafts.
+     */
+    distinct?: ApplicationDraftScalarFieldEnum | ApplicationDraftScalarFieldEnum[]
+  }
+
+  /**
+   * ApplicationDraft findFirstOrThrow
+   */
+  export type ApplicationDraftFindFirstOrThrowArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
+    /**
+     * Filter, which ApplicationDraft to fetch.
+     */
+    where?: ApplicationDraftWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ApplicationDrafts to fetch.
+     */
+    orderBy?: ApplicationDraftOrderByWithRelationInput | ApplicationDraftOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for ApplicationDrafts.
+     */
+    cursor?: ApplicationDraftWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` ApplicationDrafts from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` ApplicationDrafts.
+     */
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of ApplicationDrafts.
+     */
+    distinct?: ApplicationDraftScalarFieldEnum | ApplicationDraftScalarFieldEnum[]
+  }
+
+  /**
+   * ApplicationDraft findMany
+   */
+  export type ApplicationDraftFindManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
+    /**
+     * Filter, which ApplicationDrafts to fetch.
+     */
+    where?: ApplicationDraftWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of ApplicationDrafts to fetch.
+     */
+    orderBy?: ApplicationDraftOrderByWithRelationInput | ApplicationDraftOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing ApplicationDrafts.
+     */
+    cursor?: ApplicationDraftWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` ApplicationDrafts from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` ApplicationDrafts.
+     */
+    skip?: number
+    distinct?: ApplicationDraftScalarFieldEnum | ApplicationDraftScalarFieldEnum[]
+  }
+
+  /**
+   * ApplicationDraft create
+   */
+  export type ApplicationDraftCreateArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
+    /**
+     * The data needed to create a ApplicationDraft.
+     */
+    data: XOR<ApplicationDraftCreateInput, ApplicationDraftUncheckedCreateInput>
+  }
+
+  /**
+   * ApplicationDraft createMany
+   */
+  export type ApplicationDraftCreateManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * The data used to create many ApplicationDrafts.
+     */
+    data: ApplicationDraftCreateManyInput | ApplicationDraftCreateManyInput[]
+    skipDuplicates?: boolean
+  }
+
+  /**
+   * ApplicationDraft createManyAndReturn
+   */
+  export type ApplicationDraftCreateManyAndReturnArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelectCreateManyAndReturn<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
+    /**
+     * The data used to create many ApplicationDrafts.
+     */
+    data: ApplicationDraftCreateManyInput | ApplicationDraftCreateManyInput[]
+    skipDuplicates?: boolean
+  }
+
+  /**
+   * ApplicationDraft update
+   */
+  export type ApplicationDraftUpdateArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
+    /**
+     * The data needed to update a ApplicationDraft.
+     */
+    data: XOR<ApplicationDraftUpdateInput, ApplicationDraftUncheckedUpdateInput>
+    /**
+     * Choose, which ApplicationDraft to update.
+     */
+    where: ApplicationDraftWhereUniqueInput
+  }
+
+  /**
+   * ApplicationDraft updateMany
+   */
+  export type ApplicationDraftUpdateManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * The data used to update ApplicationDrafts.
+     */
+    data: XOR<ApplicationDraftUpdateManyMutationInput, ApplicationDraftUncheckedUpdateManyInput>
+    /**
+     * Filter which ApplicationDrafts to update
+     */
+    where?: ApplicationDraftWhereInput
+    /**
+     * Limit how many ApplicationDrafts to update.
+     */
+    limit?: number
+  }
+
+  /**
+   * ApplicationDraft updateManyAndReturn
+   */
+  export type ApplicationDraftUpdateManyAndReturnArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelectUpdateManyAndReturn<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
+    /**
+     * The data used to update ApplicationDrafts.
+     */
+    data: XOR<ApplicationDraftUpdateManyMutationInput, ApplicationDraftUncheckedUpdateManyInput>
+    /**
+     * Filter which ApplicationDrafts to update
+     */
+    where?: ApplicationDraftWhereInput
+    /**
+     * Limit how many ApplicationDrafts to update.
+     */
+    limit?: number
+  }
+
+  /**
+   * ApplicationDraft upsert
+   */
+  export type ApplicationDraftUpsertArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
+    /**
+     * The filter to search for the ApplicationDraft to update in case it exists.
+     */
+    where: ApplicationDraftWhereUniqueInput
+    /**
+     * In case the ApplicationDraft found by the `where` argument doesn't exist, create a new ApplicationDraft with this data.
+     */
+    create: XOR<ApplicationDraftCreateInput, ApplicationDraftUncheckedCreateInput>
+    /**
+     * In case the ApplicationDraft was found with the provided `where` argument, update it with this data.
+     */
+    update: XOR<ApplicationDraftUpdateInput, ApplicationDraftUncheckedUpdateInput>
+  }
+
+  /**
+   * ApplicationDraft delete
+   */
+  export type ApplicationDraftDeleteArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
+    /**
+     * Filter which ApplicationDraft to delete.
+     */
+    where: ApplicationDraftWhereUniqueInput
+  }
+
+  /**
+   * ApplicationDraft deleteMany
+   */
+  export type ApplicationDraftDeleteManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Filter which ApplicationDrafts to delete
+     */
+    where?: ApplicationDraftWhereInput
+    /**
+     * Limit how many ApplicationDrafts to delete.
+     */
+    limit?: number
+  }
+
+  /**
+   * ApplicationDraft without action
+   */
+  export type ApplicationDraftDefaultArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the ApplicationDraft
+     */
+    select?: ApplicationDraftSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the ApplicationDraft
+     */
+    omit?: ApplicationDraftOmit<ExtArgs> | null
   }
 
 
@@ -9985,10 +11153,25 @@ export namespace Prisma {
     email: 'email',
     phoneNumber: 'phoneNumber',
     message: 'message',
-    leaseId: 'leaseId'
+    leaseId: 'leaseId',
+    documentUrls: 'documentUrls'
   };
 
   export type ApplicationScalarFieldEnum = (typeof ApplicationScalarFieldEnum)[keyof typeof ApplicationScalarFieldEnum]
+
+
+  export const ApplicationDraftScalarFieldEnum: {
+    id: 'id',
+    propertyId: 'propertyId',
+    tenantCognitoId: 'tenantCognitoId',
+    data: 'data',
+    currentStep: 'currentStep',
+    documentUrls: 'documentUrls',
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt'
+  };
+
+  export type ApplicationDraftScalarFieldEnum = (typeof ApplicationDraftScalarFieldEnum)[keyof typeof ApplicationDraftScalarFieldEnum]
 
 
   export const LeaseScalarFieldEnum: {
@@ -10025,6 +11208,13 @@ export namespace Prisma {
   export type SortOrder = (typeof SortOrder)[keyof typeof SortOrder]
 
 
+  export const JsonNullValueInput: {
+    JsonNull: typeof JsonNull
+  };
+
+  export type JsonNullValueInput = (typeof JsonNullValueInput)[keyof typeof JsonNullValueInput]
+
+
   export const QueryMode: {
     default: 'default',
     insensitive: 'insensitive'
@@ -10039,6 +11229,15 @@ export namespace Prisma {
   };
 
   export type NullsOrder = (typeof NullsOrder)[keyof typeof NullsOrder]
+
+
+  export const JsonNullValueFilter: {
+    DbNull: typeof DbNull,
+    JsonNull: typeof JsonNull,
+    AnyNull: typeof AnyNull
+  };
+
+  export type JsonNullValueFilter = (typeof JsonNullValueFilter)[keyof typeof JsonNullValueFilter]
 
 
   /**
@@ -10162,6 +11361,13 @@ export namespace Prisma {
    * Reference to a field of type 'ApplicationStatus[]'
    */
   export type ListEnumApplicationStatusFieldRefInput<$PrismaModel> = FieldRefInputType<$PrismaModel, 'ApplicationStatus[]'>
+    
+
+
+  /**
+   * Reference to a field of type 'Json'
+   */
+  export type JsonFieldRefInput<$PrismaModel> = FieldRefInputType<$PrismaModel, 'Json'>
     
 
 
@@ -10528,6 +11734,7 @@ export namespace Prisma {
     phoneNumber?: StringFilter<"Application"> | string
     message?: StringNullableFilter<"Application"> | string | null
     leaseId?: IntNullableFilter<"Application"> | number | null
+    documentUrls?: StringNullableListFilter<"Application">
     property?: XOR<PropertyScalarRelationFilter, PropertyWhereInput>
     tenant?: XOR<TenantScalarRelationFilter, TenantWhereInput>
     lease?: XOR<LeaseNullableScalarRelationFilter, LeaseWhereInput> | null
@@ -10544,6 +11751,7 @@ export namespace Prisma {
     phoneNumber?: SortOrder
     message?: SortOrderInput | SortOrder
     leaseId?: SortOrderInput | SortOrder
+    documentUrls?: SortOrder
     property?: PropertyOrderByWithRelationInput
     tenant?: TenantOrderByWithRelationInput
     lease?: LeaseOrderByWithRelationInput
@@ -10563,6 +11771,7 @@ export namespace Prisma {
     email?: StringFilter<"Application"> | string
     phoneNumber?: StringFilter<"Application"> | string
     message?: StringNullableFilter<"Application"> | string | null
+    documentUrls?: StringNullableListFilter<"Application">
     property?: XOR<PropertyScalarRelationFilter, PropertyWhereInput>
     tenant?: XOR<TenantScalarRelationFilter, TenantWhereInput>
     lease?: XOR<LeaseNullableScalarRelationFilter, LeaseWhereInput> | null
@@ -10579,6 +11788,7 @@ export namespace Prisma {
     phoneNumber?: SortOrder
     message?: SortOrderInput | SortOrder
     leaseId?: SortOrderInput | SortOrder
+    documentUrls?: SortOrder
     _count?: ApplicationCountOrderByAggregateInput
     _avg?: ApplicationAvgOrderByAggregateInput
     _max?: ApplicationMaxOrderByAggregateInput
@@ -10600,6 +11810,76 @@ export namespace Prisma {
     phoneNumber?: StringWithAggregatesFilter<"Application"> | string
     message?: StringNullableWithAggregatesFilter<"Application"> | string | null
     leaseId?: IntNullableWithAggregatesFilter<"Application"> | number | null
+    documentUrls?: StringNullableListFilter<"Application">
+  }
+
+  export type ApplicationDraftWhereInput = {
+    AND?: ApplicationDraftWhereInput | ApplicationDraftWhereInput[]
+    OR?: ApplicationDraftWhereInput[]
+    NOT?: ApplicationDraftWhereInput | ApplicationDraftWhereInput[]
+    id?: IntFilter<"ApplicationDraft"> | number
+    propertyId?: IntFilter<"ApplicationDraft"> | number
+    tenantCognitoId?: StringFilter<"ApplicationDraft"> | string
+    data?: JsonFilter<"ApplicationDraft">
+    currentStep?: IntFilter<"ApplicationDraft"> | number
+    documentUrls?: StringNullableListFilter<"ApplicationDraft">
+    createdAt?: DateTimeFilter<"ApplicationDraft"> | Date | string
+    updatedAt?: DateTimeFilter<"ApplicationDraft"> | Date | string
+  }
+
+  export type ApplicationDraftOrderByWithRelationInput = {
+    id?: SortOrder
+    propertyId?: SortOrder
+    tenantCognitoId?: SortOrder
+    data?: SortOrder
+    currentStep?: SortOrder
+    documentUrls?: SortOrder
+    createdAt?: SortOrder
+    updatedAt?: SortOrder
+  }
+
+  export type ApplicationDraftWhereUniqueInput = Prisma.AtLeast<{
+    id?: number
+    AND?: ApplicationDraftWhereInput | ApplicationDraftWhereInput[]
+    OR?: ApplicationDraftWhereInput[]
+    NOT?: ApplicationDraftWhereInput | ApplicationDraftWhereInput[]
+    propertyId?: IntFilter<"ApplicationDraft"> | number
+    tenantCognitoId?: StringFilter<"ApplicationDraft"> | string
+    data?: JsonFilter<"ApplicationDraft">
+    currentStep?: IntFilter<"ApplicationDraft"> | number
+    documentUrls?: StringNullableListFilter<"ApplicationDraft">
+    createdAt?: DateTimeFilter<"ApplicationDraft"> | Date | string
+    updatedAt?: DateTimeFilter<"ApplicationDraft"> | Date | string
+  }, "id">
+
+  export type ApplicationDraftOrderByWithAggregationInput = {
+    id?: SortOrder
+    propertyId?: SortOrder
+    tenantCognitoId?: SortOrder
+    data?: SortOrder
+    currentStep?: SortOrder
+    documentUrls?: SortOrder
+    createdAt?: SortOrder
+    updatedAt?: SortOrder
+    _count?: ApplicationDraftCountOrderByAggregateInput
+    _avg?: ApplicationDraftAvgOrderByAggregateInput
+    _max?: ApplicationDraftMaxOrderByAggregateInput
+    _min?: ApplicationDraftMinOrderByAggregateInput
+    _sum?: ApplicationDraftSumOrderByAggregateInput
+  }
+
+  export type ApplicationDraftScalarWhereWithAggregatesInput = {
+    AND?: ApplicationDraftScalarWhereWithAggregatesInput | ApplicationDraftScalarWhereWithAggregatesInput[]
+    OR?: ApplicationDraftScalarWhereWithAggregatesInput[]
+    NOT?: ApplicationDraftScalarWhereWithAggregatesInput | ApplicationDraftScalarWhereWithAggregatesInput[]
+    id?: IntWithAggregatesFilter<"ApplicationDraft"> | number
+    propertyId?: IntWithAggregatesFilter<"ApplicationDraft"> | number
+    tenantCognitoId?: StringWithAggregatesFilter<"ApplicationDraft"> | string
+    data?: JsonWithAggregatesFilter<"ApplicationDraft">
+    currentStep?: IntWithAggregatesFilter<"ApplicationDraft"> | number
+    documentUrls?: StringNullableListFilter<"ApplicationDraft">
+    createdAt?: DateTimeWithAggregatesFilter<"ApplicationDraft"> | Date | string
+    updatedAt?: DateTimeWithAggregatesFilter<"ApplicationDraft"> | Date | string
   }
 
   export type LeaseWhereInput = {
@@ -11086,6 +12366,7 @@ export namespace Prisma {
     email: string
     phoneNumber: string
     message?: string | null
+    documentUrls?: ApplicationCreatedocumentUrlsInput | string[]
     property: PropertyCreateNestedOneWithoutApplicationsInput
     tenant: TenantCreateNestedOneWithoutApplicationsInput
     lease?: LeaseCreateNestedOneWithoutApplicationInput
@@ -11102,6 +12383,7 @@ export namespace Prisma {
     phoneNumber: string
     message?: string | null
     leaseId?: number | null
+    documentUrls?: ApplicationCreatedocumentUrlsInput | string[]
   }
 
   export type ApplicationUpdateInput = {
@@ -11111,6 +12393,7 @@ export namespace Prisma {
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
     property?: PropertyUpdateOneRequiredWithoutApplicationsNestedInput
     tenant?: TenantUpdateOneRequiredWithoutApplicationsNestedInput
     lease?: LeaseUpdateOneWithoutApplicationNestedInput
@@ -11127,6 +12410,7 @@ export namespace Prisma {
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
     leaseId?: NullableIntFieldUpdateOperationsInput | number | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
   }
 
   export type ApplicationCreateManyInput = {
@@ -11140,6 +12424,7 @@ export namespace Prisma {
     phoneNumber: string
     message?: string | null
     leaseId?: number | null
+    documentUrls?: ApplicationCreatedocumentUrlsInput | string[]
   }
 
   export type ApplicationUpdateManyMutationInput = {
@@ -11149,6 +12434,7 @@ export namespace Prisma {
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
   }
 
   export type ApplicationUncheckedUpdateManyInput = {
@@ -11162,6 +12448,81 @@ export namespace Prisma {
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
     leaseId?: NullableIntFieldUpdateOperationsInput | number | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
+  }
+
+  export type ApplicationDraftCreateInput = {
+    propertyId: number
+    tenantCognitoId: string
+    data: JsonNullValueInput | InputJsonValue
+    currentStep: number
+    documentUrls?: ApplicationDraftCreatedocumentUrlsInput | string[]
+    createdAt?: Date | string
+    updatedAt?: Date | string
+  }
+
+  export type ApplicationDraftUncheckedCreateInput = {
+    id?: number
+    propertyId: number
+    tenantCognitoId: string
+    data: JsonNullValueInput | InputJsonValue
+    currentStep: number
+    documentUrls?: ApplicationDraftCreatedocumentUrlsInput | string[]
+    createdAt?: Date | string
+    updatedAt?: Date | string
+  }
+
+  export type ApplicationDraftUpdateInput = {
+    propertyId?: IntFieldUpdateOperationsInput | number
+    tenantCognitoId?: StringFieldUpdateOperationsInput | string
+    data?: JsonNullValueInput | InputJsonValue
+    currentStep?: IntFieldUpdateOperationsInput | number
+    documentUrls?: ApplicationDraftUpdatedocumentUrlsInput | string[]
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+    updatedAt?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type ApplicationDraftUncheckedUpdateInput = {
+    id?: IntFieldUpdateOperationsInput | number
+    propertyId?: IntFieldUpdateOperationsInput | number
+    tenantCognitoId?: StringFieldUpdateOperationsInput | string
+    data?: JsonNullValueInput | InputJsonValue
+    currentStep?: IntFieldUpdateOperationsInput | number
+    documentUrls?: ApplicationDraftUpdatedocumentUrlsInput | string[]
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+    updatedAt?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type ApplicationDraftCreateManyInput = {
+    id?: number
+    propertyId: number
+    tenantCognitoId: string
+    data: JsonNullValueInput | InputJsonValue
+    currentStep: number
+    documentUrls?: ApplicationDraftCreatedocumentUrlsInput | string[]
+    createdAt?: Date | string
+    updatedAt?: Date | string
+  }
+
+  export type ApplicationDraftUpdateManyMutationInput = {
+    propertyId?: IntFieldUpdateOperationsInput | number
+    tenantCognitoId?: StringFieldUpdateOperationsInput | string
+    data?: JsonNullValueInput | InputJsonValue
+    currentStep?: IntFieldUpdateOperationsInput | number
+    documentUrls?: ApplicationDraftUpdatedocumentUrlsInput | string[]
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+    updatedAt?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type ApplicationDraftUncheckedUpdateManyInput = {
+    id?: IntFieldUpdateOperationsInput | number
+    propertyId?: IntFieldUpdateOperationsInput | number
+    tenantCognitoId?: StringFieldUpdateOperationsInput | string
+    data?: JsonNullValueInput | InputJsonValue
+    currentStep?: IntFieldUpdateOperationsInput | number
+    documentUrls?: ApplicationDraftUpdatedocumentUrlsInput | string[]
+    createdAt?: DateTimeFieldUpdateOperationsInput | Date | string
+    updatedAt?: DateTimeFieldUpdateOperationsInput | Date | string
   }
 
   export type LeaseCreateInput = {
@@ -11814,6 +13175,7 @@ export namespace Prisma {
     phoneNumber?: SortOrder
     message?: SortOrder
     leaseId?: SortOrder
+    documentUrls?: SortOrder
   }
 
   export type ApplicationAvgOrderByAggregateInput = {
@@ -11880,6 +13242,94 @@ export namespace Prisma {
     _count?: NestedIntNullableFilter<$PrismaModel>
     _min?: NestedStringNullableFilter<$PrismaModel>
     _max?: NestedStringNullableFilter<$PrismaModel>
+  }
+  export type JsonFilter<$PrismaModel = never> = 
+    | PatchUndefined<
+        Either<Required<JsonFilterBase<$PrismaModel>>, Exclude<keyof Required<JsonFilterBase<$PrismaModel>>, 'path'>>,
+        Required<JsonFilterBase<$PrismaModel>>
+      >
+    | OptionalFlat<Omit<Required<JsonFilterBase<$PrismaModel>>, 'path'>>
+
+  export type JsonFilterBase<$PrismaModel = never> = {
+    equals?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | JsonNullValueFilter
+    path?: string[]
+    string_contains?: string | StringFieldRefInput<$PrismaModel>
+    string_starts_with?: string | StringFieldRefInput<$PrismaModel>
+    string_ends_with?: string | StringFieldRefInput<$PrismaModel>
+    array_starts_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null
+    array_ends_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null
+    array_contains?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null
+    lt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    lte?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    gt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    gte?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    not?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | JsonNullValueFilter
+  }
+
+  export type ApplicationDraftCountOrderByAggregateInput = {
+    id?: SortOrder
+    propertyId?: SortOrder
+    tenantCognitoId?: SortOrder
+    data?: SortOrder
+    currentStep?: SortOrder
+    documentUrls?: SortOrder
+    createdAt?: SortOrder
+    updatedAt?: SortOrder
+  }
+
+  export type ApplicationDraftAvgOrderByAggregateInput = {
+    id?: SortOrder
+    propertyId?: SortOrder
+    currentStep?: SortOrder
+  }
+
+  export type ApplicationDraftMaxOrderByAggregateInput = {
+    id?: SortOrder
+    propertyId?: SortOrder
+    tenantCognitoId?: SortOrder
+    currentStep?: SortOrder
+    createdAt?: SortOrder
+    updatedAt?: SortOrder
+  }
+
+  export type ApplicationDraftMinOrderByAggregateInput = {
+    id?: SortOrder
+    propertyId?: SortOrder
+    tenantCognitoId?: SortOrder
+    currentStep?: SortOrder
+    createdAt?: SortOrder
+    updatedAt?: SortOrder
+  }
+
+  export type ApplicationDraftSumOrderByAggregateInput = {
+    id?: SortOrder
+    propertyId?: SortOrder
+    currentStep?: SortOrder
+  }
+  export type JsonWithAggregatesFilter<$PrismaModel = never> = 
+    | PatchUndefined<
+        Either<Required<JsonWithAggregatesFilterBase<$PrismaModel>>, Exclude<keyof Required<JsonWithAggregatesFilterBase<$PrismaModel>>, 'path'>>,
+        Required<JsonWithAggregatesFilterBase<$PrismaModel>>
+      >
+    | OptionalFlat<Omit<Required<JsonWithAggregatesFilterBase<$PrismaModel>>, 'path'>>
+
+  export type JsonWithAggregatesFilterBase<$PrismaModel = never> = {
+    equals?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | JsonNullValueFilter
+    path?: string[]
+    string_contains?: string | StringFieldRefInput<$PrismaModel>
+    string_starts_with?: string | StringFieldRefInput<$PrismaModel>
+    string_ends_with?: string | StringFieldRefInput<$PrismaModel>
+    array_starts_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null
+    array_ends_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null
+    array_contains?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null
+    lt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    lte?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    gt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    gte?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    not?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | JsonNullValueFilter
+    _count?: NestedIntFilter<$PrismaModel>
+    _min?: NestedJsonFilter<$PrismaModel>
+    _max?: NestedJsonFilter<$PrismaModel>
   }
 
   export type ApplicationNullableScalarRelationFilter = {
@@ -12495,6 +13945,10 @@ export namespace Prisma {
     deleteMany?: PropertyScalarWhereInput | PropertyScalarWhereInput[]
   }
 
+  export type ApplicationCreatedocumentUrlsInput = {
+    set: string[]
+  }
+
   export type PropertyCreateNestedOneWithoutApplicationsInput = {
     create?: XOR<PropertyCreateWithoutApplicationsInput, PropertyUncheckedCreateWithoutApplicationsInput>
     connectOrCreate?: PropertyCreateOrConnectWithoutApplicationsInput
@@ -12521,6 +13975,11 @@ export namespace Prisma {
     set?: string | null
   }
 
+  export type ApplicationUpdatedocumentUrlsInput = {
+    set?: string[]
+    push?: string | string[]
+  }
+
   export type PropertyUpdateOneRequiredWithoutApplicationsNestedInput = {
     create?: XOR<PropertyCreateWithoutApplicationsInput, PropertyUncheckedCreateWithoutApplicationsInput>
     connectOrCreate?: PropertyCreateOrConnectWithoutApplicationsInput
@@ -12545,6 +14004,15 @@ export namespace Prisma {
     delete?: LeaseWhereInput | boolean
     connect?: LeaseWhereUniqueInput
     update?: XOR<XOR<LeaseUpdateToOneWithWhereWithoutApplicationInput, LeaseUpdateWithoutApplicationInput>, LeaseUncheckedUpdateWithoutApplicationInput>
+  }
+
+  export type ApplicationDraftCreatedocumentUrlsInput = {
+    set: string[]
+  }
+
+  export type ApplicationDraftUpdatedocumentUrlsInput = {
+    set?: string[]
+    push?: string | string[]
   }
 
   export type PropertyCreateNestedOneWithoutLeasesInput = {
@@ -12908,6 +14376,28 @@ export namespace Prisma {
     _min?: NestedStringNullableFilter<$PrismaModel>
     _max?: NestedStringNullableFilter<$PrismaModel>
   }
+  export type NestedJsonFilter<$PrismaModel = never> = 
+    | PatchUndefined<
+        Either<Required<NestedJsonFilterBase<$PrismaModel>>, Exclude<keyof Required<NestedJsonFilterBase<$PrismaModel>>, 'path'>>,
+        Required<NestedJsonFilterBase<$PrismaModel>>
+      >
+    | OptionalFlat<Omit<Required<NestedJsonFilterBase<$PrismaModel>>, 'path'>>
+
+  export type NestedJsonFilterBase<$PrismaModel = never> = {
+    equals?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | JsonNullValueFilter
+    path?: string[]
+    string_contains?: string | StringFieldRefInput<$PrismaModel>
+    string_starts_with?: string | StringFieldRefInput<$PrismaModel>
+    string_ends_with?: string | StringFieldRefInput<$PrismaModel>
+    array_starts_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null
+    array_ends_with?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null
+    array_contains?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | null
+    lt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    lte?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    gt?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    gte?: InputJsonValue | JsonFieldRefInput<$PrismaModel>
+    not?: InputJsonValue | JsonFieldRefInput<$PrismaModel> | JsonNullValueFilter
+  }
 
   export type NestedEnumPaymentStatusFilter<$PrismaModel = never> = {
     equals?: $Enums.PaymentStatus | EnumPaymentStatusFieldRefInput<$PrismaModel>
@@ -12984,6 +14474,7 @@ export namespace Prisma {
     email: string
     phoneNumber: string
     message?: string | null
+    documentUrls?: ApplicationCreatedocumentUrlsInput | string[]
     tenant: TenantCreateNestedOneWithoutApplicationsInput
     lease?: LeaseCreateNestedOneWithoutApplicationInput
   }
@@ -12998,6 +14489,7 @@ export namespace Prisma {
     phoneNumber: string
     message?: string | null
     leaseId?: number | null
+    documentUrls?: ApplicationCreatedocumentUrlsInput | string[]
   }
 
   export type ApplicationCreateOrConnectWithoutPropertyInput = {
@@ -13169,6 +14661,7 @@ export namespace Prisma {
     phoneNumber?: StringFilter<"Application"> | string
     message?: StringNullableFilter<"Application"> | string | null
     leaseId?: IntNullableFilter<"Application"> | number | null
+    documentUrls?: StringNullableListFilter<"Application">
   }
 
   export type TenantUpsertWithWhereUniqueWithoutFavoritesInput = {
@@ -13436,6 +14929,7 @@ export namespace Prisma {
     email: string
     phoneNumber: string
     message?: string | null
+    documentUrls?: ApplicationCreatedocumentUrlsInput | string[]
     property: PropertyCreateNestedOneWithoutApplicationsInput
     lease?: LeaseCreateNestedOneWithoutApplicationInput
   }
@@ -13450,6 +14944,7 @@ export namespace Prisma {
     phoneNumber: string
     message?: string | null
     leaseId?: number | null
+    documentUrls?: ApplicationCreatedocumentUrlsInput | string[]
   }
 
   export type ApplicationCreateOrConnectWithoutTenantInput = {
@@ -13957,6 +15452,7 @@ export namespace Prisma {
     email: string
     phoneNumber: string
     message?: string | null
+    documentUrls?: ApplicationCreatedocumentUrlsInput | string[]
     property: PropertyCreateNestedOneWithoutApplicationsInput
     tenant: TenantCreateNestedOneWithoutApplicationsInput
   }
@@ -13971,6 +15467,7 @@ export namespace Prisma {
     email: string
     phoneNumber: string
     message?: string | null
+    documentUrls?: ApplicationCreatedocumentUrlsInput | string[]
   }
 
   export type ApplicationCreateOrConnectWithoutLeaseInput = {
@@ -14117,6 +15614,7 @@ export namespace Prisma {
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
     property?: PropertyUpdateOneRequiredWithoutApplicationsNestedInput
     tenant?: TenantUpdateOneRequiredWithoutApplicationsNestedInput
   }
@@ -14131,6 +15629,7 @@ export namespace Prisma {
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
   }
 
   export type PaymentUpsertWithWhereUniqueWithoutLeaseInput = {
@@ -14239,6 +15738,7 @@ export namespace Prisma {
     phoneNumber: string
     message?: string | null
     leaseId?: number | null
+    documentUrls?: ApplicationCreatedocumentUrlsInput | string[]
   }
 
   export type LeaseUpdateWithoutPropertyInput = {
@@ -14278,6 +15778,7 @@ export namespace Prisma {
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
     tenant?: TenantUpdateOneRequiredWithoutApplicationsNestedInput
     lease?: LeaseUpdateOneWithoutApplicationNestedInput
   }
@@ -14292,6 +15793,7 @@ export namespace Prisma {
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
     leaseId?: NullableIntFieldUpdateOperationsInput | number | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
   }
 
   export type ApplicationUncheckedUpdateManyWithoutPropertyInput = {
@@ -14304,6 +15806,7 @@ export namespace Prisma {
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
     leaseId?: NullableIntFieldUpdateOperationsInput | number | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
   }
 
   export type TenantUpdateWithoutFavoritesInput = {
@@ -14469,6 +15972,7 @@ export namespace Prisma {
     phoneNumber: string
     message?: string | null
     leaseId?: number | null
+    documentUrls?: ApplicationCreatedocumentUrlsInput | string[]
   }
 
   export type LeaseCreateManyTenantInput = {
@@ -14635,6 +16139,7 @@ export namespace Prisma {
     email?: StringFieldUpdateOperationsInput | string
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
     property?: PropertyUpdateOneRequiredWithoutApplicationsNestedInput
     lease?: LeaseUpdateOneWithoutApplicationNestedInput
   }
@@ -14649,6 +16154,7 @@ export namespace Prisma {
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
     leaseId?: NullableIntFieldUpdateOperationsInput | number | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
   }
 
   export type ApplicationUncheckedUpdateManyWithoutTenantInput = {
@@ -14661,6 +16167,7 @@ export namespace Prisma {
     phoneNumber?: StringFieldUpdateOperationsInput | string
     message?: NullableStringFieldUpdateOperationsInput | string | null
     leaseId?: NullableIntFieldUpdateOperationsInput | number | null
+    documentUrls?: ApplicationUpdatedocumentUrlsInput | string[]
   }
 
   export type LeaseUpdateWithoutTenantInput = {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.740.0",
         "@aws-sdk/lib-storage": "^3.740.0",
+        "@aws-sdk/s3-request-presigner": "^3.740.0",
         "@prisma/client": "^6.3.0",
         "@terraformer/wkt": "^2.2.1",
         "axios": "^1.7.9",
@@ -777,6 +778,161 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.873.0.tgz",
+      "integrity": "sha512-DiVlfCpdR7EaZSNPQwBB1jq8INWezKMWb3BUOWxrOcIcS3p2WpKbYl0H76D6TCHvQzXRVgKSSM6tHuWPoJtUHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-format-url": "3.873.0",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/core": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.873.0.tgz",
+      "integrity": "sha512-WrROjp8X1VvmnZ4TBzwM7RF+EB3wRaY9kQJLXw+Aes0/3zRjUXvGIlseobGJMqMEGnM0YekD2F87UaVfot1xeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/xml-builder": "3.873.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.873.0.tgz",
+      "integrity": "sha512-bOoWGH57ORK2yKOqJMmxBV4b3yMK8Pc0/K2A98MNPuQedXaxxwzRfsT2Qw+PpfYkiijrrNFqDYmQRGntxJ2h8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-arn-parser": "3.873.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-stream": "^4.2.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.873.0.tgz",
+      "integrity": "sha512-FQ5OIXw1rmDud7f/VO9y2Mg9rX1o4MnngRKUOD8mS9ALK4uxKrTczb4jA+uJLSLwTqMGs3bcB1RzbMW1zWTMwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/types": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+      "integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.873.0.tgz",
+      "integrity": "sha512-qag+VTqnJWDn8zTAXX4wiVioa0hZDQMtbZcGRERVnLar4/3/VIKBhxX2XibNQXFu1ufgcRn4YntT/XEPecFWcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
+      "integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.740.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.740.0.tgz",
@@ -845,6 +1001,34 @@
         "@aws-sdk/types": "3.734.0",
         "@smithy/types": "^4.1.0",
         "@smithy/util-endpoints": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.873.0.tgz",
+      "integrity": "sha512-v//b9jFnhzTKKV3HFTw2MakdM22uBAs2lBov51BWmFXuFtSTdBLrR7zgfetQPE3PVkFai0cmtJQPdc3MX+T/cQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/querystring-builder": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+      "integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1039,12 +1223,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.5.tgz",
+      "integrity": "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1093,22 +1277,44 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.2.tgz",
-      "integrity": "sha512-htwQXkbdF13uwwDevz9BEzL5ABK+1sJpVQXywwGSH973AVOvisHNfpcB8A8761G6XgHoS2kHPqc9DqHJ2gp+/Q==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.8.0.tgz",
+      "integrity": "sha512-EYqsIYJmkR1VhVE9pccnk353xhs+lB6btdutJEtsp7R055haMJp2yE16eSxw8fv+G0WUY6vqxyYOP8kOqawxYQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-stream": "^4.0.2",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-stream": "^4.2.4",
         "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT"
+    },
+    "node_modules/@smithy/core/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
@@ -1198,14 +1404,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-      "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
+      "integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/querystring-builder": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-base64": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -1311,18 +1517,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.3.tgz",
-      "integrity": "sha512-YdbmWhQF5kIxZjWqPIgboVfi8i5XgiYMM7GGKFMTvBei4XjNQfNv8sukT50ITvgnWKKKpOtp0C0h7qixLgb77Q==",
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.18.tgz",
+      "integrity": "sha512-ZhvqcVRPZxnZlokcPaTwb+r+h4yOIOCJmx0v2d1bpVlmP465g3qpVSf7wxcq5zZdu4jb0H4yIMxuPwDJSQc3MQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.1.2",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/core": "^3.8.0",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-middleware": "^4.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1363,12 +1569,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
-      "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
+      "integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1376,12 +1583,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-      "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
+      "integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1389,14 +1596,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-      "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
+      "integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1404,15 +1611,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.2.tgz",
-      "integrity": "sha512-X66H9aah9hisLLSnGuzRYba6vckuFtGE+a5DcHLliI/YlqKrGoxhisD5XbX44KyoeRzoNlGr94eTsMVHFAzPOw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.1.tgz",
+      "integrity": "sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/abort-controller": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/querystring-builder": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1420,12 +1627,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-      "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
+      "integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1433,12 +1640,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-      "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+      "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1446,12 +1653,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-      "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+      "integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-uri-escape": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -1460,12 +1667,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-      "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
+      "integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1485,12 +1692,12 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-      "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
+      "integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1498,16 +1705,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-      "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
+      "integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-middleware": "^4.0.5",
         "@smithy/util-uri-escape": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
@@ -1517,17 +1724,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.3.tgz",
-      "integrity": "sha512-A2Hz85pu8BJJaYFdX8yb1yocqigyqBzn+OVaVgm+Kwi/DkN8vhN2kbDVEfADo6jXf5hPKquMLGA3UINA64UZ7A==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.10.tgz",
+      "integrity": "sha512-iW6HjXqN0oPtRS0NK/zzZ4zZeGESIFcxj2FkWed3mcK8jdSdHzvnCKXSjvewESKAgGKAbJRA+OsaqKhkdYRbQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.1.2",
-        "@smithy/middleware-endpoint": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-stream": "^4.0.2",
+        "@smithy/core": "^3.8.0",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-stream": "^4.2.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1535,9 +1742,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+      "integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1547,13 +1754,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-      "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
+      "integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/querystring-parser": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1684,12 +1891,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-      "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
+      "integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1711,14 +1918,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.0.2.tgz",
-      "integrity": "sha512-0eZ4G5fRzIoewtHtwaYyl8g2C+osYOT4KClXgfdNEDAgkbe2TYPqcnw4GAWabqkZCax2ihRGPe9LZnsPdIUIHA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
+      "integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/types": "^4.1.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-hex-encoding": "^4.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.740.0",
     "@aws-sdk/lib-storage": "^3.740.0",
+    "@aws-sdk/s3-request-presigner": "^3.740.0",
     "@prisma/client": "^6.3.0",
     "@terraformer/wkt": "^2.2.1",
     "axios": "^1.7.9",

--- a/server/prisma/migrations/20250210120000_application_drafts/migration.sql
+++ b/server/prisma/migrations/20250210120000_application_drafts/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "Application" ADD COLUMN "documentUrls" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateTable
+CREATE TABLE "ApplicationDraft" (
+  "id" SERIAL PRIMARY KEY,
+  "propertyId" INTEGER NOT NULL,
+  "tenantCognitoId" TEXT NOT NULL,
+  "data" JSONB NOT NULL,
+  "currentStep" INTEGER NOT NULL,
+  "documentUrls" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -141,10 +141,22 @@ model Application {
   phoneNumber     String
   message         String?
   leaseId         Int?              @unique
+  documentUrls    String[]          @default([])
 
   property Property @relation(fields: [propertyId], references: [id])
   tenant   Tenant   @relation(fields: [tenantCognitoId], references: [cognitoId])
   lease    Lease?   @relation(fields: [leaseId], references: [id])
+}
+
+model ApplicationDraft {
+  id              Int      @id @default(autoincrement())
+  propertyId      Int
+  tenantCognitoId String
+  data            Json
+  currentStep     Int
+  documentUrls    String[] @default([])
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 }
 
 model Lease {

--- a/server/src/routes/applicationRoutes.ts
+++ b/server/src/routes/applicationRoutes.ts
@@ -4,6 +4,9 @@ import {
   createApplication,
   listApplications,
   updateApplicationStatus,
+  saveApplicationDraft,
+  getApplicationDraft,
+  generatePresignedUrl,
 } from "../controllers/applicationControllers";
 
 const router = express.Router();
@@ -11,5 +14,20 @@ const router = express.Router();
 router.post("/", authMiddleware(["tenant"]), createApplication);
 router.put("/:id/status", authMiddleware(["manager"]), updateApplicationStatus);
 router.get("/", authMiddleware(["manager", "tenant"]), listApplications);
+router.post(
+  "/draft",
+  authMiddleware(["tenant"]),
+  saveApplicationDraft
+);
+router.get(
+  "/draft",
+  authMiddleware(["tenant"]),
+  getApplicationDraft
+);
+router.post(
+  "/presigned-url",
+  authMiddleware(["tenant"]),
+  generatePresignedUrl
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- add application drafts and document storage to Prisma schema
- implement draft save and S3 presigned upload endpoints
- build multi-step application wizard with autosave and document upload

## Testing
- `npm run build` in `server`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68a97d9341888328ab9356d0771af65a