### PR TITLE
Add property editing with optimistic cache and soft delete

### DIFF
--- a/client/src/app/(dashboard)/managers/properties/page.tsx
+++ b/client/src/app/(dashboard)/managers/properties/page.tsx
@@ -3,8 +3,16 @@
 import Card from "@/components/Card";
 import Header from "@/components/Header";
 import Loading from "@/components/Loading";
-import { useGetAuthUserQuery, useGetManagerPropertiesQuery } from "@/state/api";
-import React from "react";
+import {
+  useGetAuthUserQuery,
+  useGetManagerPropertiesQuery,
+  useUpdatePropertyMutation,
+  useSoftDeletePropertyMutation,
+} from "@/state/api";
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import { Property } from "@/types/prismaTypes";
 
 const Properties = () => {
   const { data: authUser } = useGetAuthUserQuery();
@@ -15,6 +23,33 @@ const Properties = () => {
   } = useGetManagerPropertiesQuery(authUser?.cognitoInfo?.userId || "", {
     skip: !authUser?.cognitoInfo?.userId,
   });
+  const [updateProperty] = useUpdatePropertyMutation();
+  const [softDeleteProperty] = useSoftDeletePropertyMutation();
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const { register, handleSubmit, reset } = useForm<{
+    name: string;
+    pricePerMonth: number;
+  }>();
+
+  const startEdit = (property: Property) => {
+    setEditingId(property.id);
+    reset({ name: property.name, pricePerMonth: property.pricePerMonth });
+  };
+
+  const onSubmit = async (data: { name: string; pricePerMonth: number }) => {
+    if (!editingId || !authUser?.cognitoInfo?.userId) return;
+    await updateProperty({
+      id: editingId,
+      managerCognitoId: authUser.cognitoInfo.userId,
+      ...data,
+    });
+    setEditingId(null);
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!authUser?.cognitoInfo?.userId) return;
+    await softDeleteProperty({ id, managerCognitoId: authUser.cognitoInfo.userId });
+  };
 
   if (isLoading) return <Loading />;
   if (error) return <div>Error loading manager properties</div>;
@@ -27,14 +62,63 @@ const Properties = () => {
       />
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
         {managerProperties?.map((property) => (
-          <Card
-            key={property.id}
-            property={property}
-            isFavorite={false}
-            onFavoriteToggle={() => {}}
-            showFavoriteButton={false}
-            propertyLink={`/managers/properties/${property.id}`}
-          />
+          <div key={property.id} className="mb-4">
+            <Card
+              property={property}
+              isFavorite={false}
+              onFavoriteToggle={() => {}}
+              showFavoriteButton={false}
+              propertyLink={`/managers/properties/${property.id}`}
+            />
+            <div className="flex gap-2 mt-2">
+              <Button
+                type="button"
+                className="bg-secondary-500 text-white hover:bg-secondary-600"
+                onClick={() => startEdit(property)}
+              >
+                Edit
+              </Button>
+              <Button
+                type="button"
+                className="bg-red-500 text-white hover:bg-red-600"
+                onClick={() => handleDelete(property.id)}
+              >
+                Delete
+              </Button>
+            </div>
+            {editingId === property.id && (
+              <form
+                onSubmit={handleSubmit(onSubmit)}
+                className="mt-2 bg-white p-4 rounded-xl shadow"
+              >
+                <input
+                  className="border p-2 w-full mb-2"
+                  {...register("name")}
+                />
+                <input
+                  className="border p-2 w-full mb-2"
+                  type="number"
+                  step="0.01"
+                  {...register("pricePerMonth", { valueAsNumber: true })}
+                />
+                <div className="flex gap-2">
+                  <Button
+                    type="submit"
+                    className="bg-primary-700 text-white hover:bg-primary-800"
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setEditingId(null)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </form>
+            )}
+          </div>
         ))}
       </div>
       {(!managerProperties || managerProperties.length === 0) && (

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -261,6 +261,85 @@ export const api = createApi({
       },
     }),
 
+    updateProperty: build.mutation<
+      Property,
+      { id: number; managerCognitoId: string } & Partial<Property>
+    >({
+      query: ({ id, managerCognitoId: _manager, ...data }) => ({
+        url: `properties/${id}`,
+        method: "PUT",
+        body: data,
+      }),
+      async onQueryStarted(
+        { id, managerCognitoId, ...patch },
+        { dispatch, queryFulfilled }
+      ) {
+        const patchManager = dispatch(
+          api.util.updateQueryData(
+            "getManagerProperties",
+            managerCognitoId,
+            (draft) => {
+              const property = draft.find((p: Property) => p.id === id);
+              if (property) Object.assign(property, patch);
+            }
+          )
+        );
+        const patchProperty = dispatch(
+          api.util.updateQueryData("getProperty", id, (draft) => {
+            Object.assign(draft, patch);
+          })
+        );
+        try {
+          await withToast(queryFulfilled, {
+            success: "Property updated successfully!",
+            error: "Failed to update property.",
+          });
+        } catch {
+          patchManager.undo();
+          patchProperty.undo();
+        }
+      },
+    }),
+
+    softDeleteProperty: build.mutation<
+      void,
+      { id: number; managerCognitoId: string }
+    >({
+      query: ({ id }) => ({
+        url: `properties/${id}`,
+        method: "DELETE",
+      }),
+      async onQueryStarted(
+        { id, managerCognitoId },
+        { dispatch, queryFulfilled }
+      ) {
+        const patchManager = dispatch(
+          api.util.updateQueryData(
+            "getManagerProperties",
+            managerCognitoId,
+            (draft) => {
+              const index = draft.findIndex((p: Property) => p.id === id);
+              if (index !== -1) draft.splice(index, 1);
+            }
+          )
+        );
+        const patchProperty = dispatch(
+          api.util.updateQueryData("getProperty", id, (draft) => {
+            (draft as Property).isDeleted = true;
+          })
+        );
+        try {
+          await withToast(queryFulfilled, {
+            success: "Property removed successfully!",
+            error: "Failed to remove property.",
+          });
+        } catch {
+          patchManager.undo();
+          patchProperty.undo();
+        }
+      },
+    }),
+
     // lease related enpoints
     getLeases: build.query<Lease[], number>({
       query: () => "leases",
@@ -360,6 +439,8 @@ export const {
   useGetCurrentResidencesQuery,
   useGetManagerPropertiesQuery,
   useCreatePropertyMutation,
+  useUpdatePropertyMutation,
+  useSoftDeletePropertyMutation,
   useGetTenantQuery,
   useAddFavoritePropertyMutation,
   useRemoveFavoritePropertyMutation,

--- a/client/src/types/prismaTypes.d.ts
+++ b/client/src/types/prismaTypes.d.ts
@@ -1756,6 +1756,7 @@ export namespace Prisma {
     numberOfReviews: number | null
     locationId: number | null
     managerCognitoId: string | null
+    isDeleted: boolean | null
   }
 
   export type PropertyMaxAggregateOutputType = {
@@ -1776,6 +1777,7 @@ export namespace Prisma {
     numberOfReviews: number | null
     locationId: number | null
     managerCognitoId: string | null
+    isDeleted: boolean | null
   }
 
   export type PropertyCountAggregateOutputType = {
@@ -1799,6 +1801,7 @@ export namespace Prisma {
     numberOfReviews: number
     locationId: number
     managerCognitoId: number
+    isDeleted: number
     _all: number
   }
 
@@ -1847,6 +1850,7 @@ export namespace Prisma {
     numberOfReviews?: true
     locationId?: true
     managerCognitoId?: true
+    isDeleted?: true
   }
 
   export type PropertyMaxAggregateInputType = {
@@ -1867,6 +1871,7 @@ export namespace Prisma {
     numberOfReviews?: true
     locationId?: true
     managerCognitoId?: true
+    isDeleted?: true
   }
 
   export type PropertyCountAggregateInputType = {
@@ -1890,6 +1895,7 @@ export namespace Prisma {
     numberOfReviews?: true
     locationId?: true
     managerCognitoId?: true
+    isDeleted?: true
     _all?: true
   }
 
@@ -2000,6 +2006,7 @@ export namespace Prisma {
     numberOfReviews: number | null
     locationId: number
     managerCognitoId: string
+    isDeleted: boolean
     _count: PropertyCountAggregateOutputType | null
     _avg: PropertyAvgAggregateOutputType | null
     _sum: PropertySumAggregateOutputType | null
@@ -2042,6 +2049,7 @@ export namespace Prisma {
     numberOfReviews?: boolean
     locationId?: boolean
     managerCognitoId?: boolean
+    isDeleted?: boolean
     location?: boolean | LocationDefaultArgs<ExtArgs>
     manager?: boolean | ManagerDefaultArgs<ExtArgs>
     leases?: boolean | Property$leasesArgs<ExtArgs>
@@ -2072,6 +2080,7 @@ export namespace Prisma {
     numberOfReviews?: boolean
     locationId?: boolean
     managerCognitoId?: boolean
+    isDeleted?: boolean
     location?: boolean | LocationDefaultArgs<ExtArgs>
     manager?: boolean | ManagerDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["property"]>
@@ -2097,6 +2106,7 @@ export namespace Prisma {
     numberOfReviews?: boolean
     locationId?: boolean
     managerCognitoId?: boolean
+    isDeleted?: boolean
     location?: boolean | LocationDefaultArgs<ExtArgs>
     manager?: boolean | ManagerDefaultArgs<ExtArgs>
   }, ExtArgs["result"]["property"]>
@@ -2122,9 +2132,10 @@ export namespace Prisma {
     numberOfReviews?: boolean
     locationId?: boolean
     managerCognitoId?: boolean
+    isDeleted?: boolean
   }
 
-  export type PropertyOmit<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetOmit<"id" | "name" | "description" | "pricePerMonth" | "securityDeposit" | "applicationFee" | "photoUrls" | "amenities" | "highlights" | "isPetsAllowed" | "isParkingIncluded" | "beds" | "baths" | "squareFeet" | "propertyType" | "postedDate" | "averageRating" | "numberOfReviews" | "locationId" | "managerCognitoId", ExtArgs["result"]["property"]>
+  export type PropertyOmit<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetOmit<"id" | "name" | "description" | "pricePerMonth" | "securityDeposit" | "applicationFee" | "photoUrls" | "amenities" | "highlights" | "isPetsAllowed" | "isParkingIncluded" | "beds" | "baths" | "squareFeet" | "propertyType" | "postedDate" | "averageRating" | "numberOfReviews" | "locationId" | "managerCognitoId" | "isDeleted", ExtArgs["result"]["property"]>
   export type PropertyInclude<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
     location?: boolean | LocationDefaultArgs<ExtArgs>
     manager?: boolean | ManagerDefaultArgs<ExtArgs>
@@ -2174,6 +2185,7 @@ export namespace Prisma {
       numberOfReviews: number | null
       locationId: number
       managerCognitoId: string
+      isDeleted: boolean
     }, ExtArgs["result"]["property"]>
     composites: {}
   }
@@ -2623,6 +2635,7 @@ export namespace Prisma {
     readonly numberOfReviews: FieldRef<"Property", 'Int'>
     readonly locationId: FieldRef<"Property", 'Int'>
     readonly managerCognitoId: FieldRef<"Property", 'String'>
+    readonly isDeleted: FieldRef<"Property", 'Boolean'>
   }
     
 
@@ -9935,7 +9948,8 @@ export namespace Prisma {
     averageRating: 'averageRating',
     numberOfReviews: 'numberOfReviews',
     locationId: 'locationId',
-    managerCognitoId: 'managerCognitoId'
+    managerCognitoId: 'managerCognitoId',
+    isDeleted: 'isDeleted'
   };
 
   export type PropertyScalarFieldEnum = (typeof PropertyScalarFieldEnum)[keyof typeof PropertyScalarFieldEnum]
@@ -10206,6 +10220,7 @@ export namespace Prisma {
     numberOfReviews?: IntNullableFilter<"Property"> | number | null
     locationId?: IntFilter<"Property"> | number
     managerCognitoId?: StringFilter<"Property"> | string
+    isDeleted?: BoolFilter<"Property"> | boolean
     location?: XOR<LocationScalarRelationFilter, LocationWhereInput>
     manager?: XOR<ManagerScalarRelationFilter, ManagerWhereInput>
     leases?: LeaseListRelationFilter
@@ -10235,6 +10250,7 @@ export namespace Prisma {
     numberOfReviews?: SortOrderInput | SortOrder
     locationId?: SortOrder
     managerCognitoId?: SortOrder
+    isDeleted?: SortOrder
     location?: LocationOrderByWithRelationInput
     manager?: ManagerOrderByWithRelationInput
     leases?: LeaseOrderByRelationAggregateInput
@@ -10267,6 +10283,7 @@ export namespace Prisma {
     numberOfReviews?: IntNullableFilter<"Property"> | number | null
     locationId?: IntFilter<"Property"> | number
     managerCognitoId?: StringFilter<"Property"> | string
+    isDeleted?: BoolFilter<"Property"> | boolean
     location?: XOR<LocationScalarRelationFilter, LocationWhereInput>
     manager?: XOR<ManagerScalarRelationFilter, ManagerWhereInput>
     leases?: LeaseListRelationFilter
@@ -10296,6 +10313,7 @@ export namespace Prisma {
     numberOfReviews?: SortOrderInput | SortOrder
     locationId?: SortOrder
     managerCognitoId?: SortOrder
+    isDeleted?: SortOrder
     _count?: PropertyCountOrderByAggregateInput
     _avg?: PropertyAvgOrderByAggregateInput
     _max?: PropertyMaxOrderByAggregateInput
@@ -10327,6 +10345,7 @@ export namespace Prisma {
     numberOfReviews?: IntNullableWithAggregatesFilter<"Property"> | number | null
     locationId?: IntWithAggregatesFilter<"Property"> | number
     managerCognitoId?: StringWithAggregatesFilter<"Property"> | string
+    isDeleted?: BoolWithAggregatesFilter<"Property"> | boolean
   }
 
   export type ManagerWhereInput = {
@@ -10763,6 +10782,7 @@ export namespace Prisma {
     postedDate?: Date | string
     averageRating?: number | null
     numberOfReviews?: number | null
+    isDeleted?: boolean
     location: LocationCreateNestedOneWithoutPropertiesInput
     manager: ManagerCreateNestedOneWithoutManagedPropertiesInput
     leases?: LeaseCreateNestedManyWithoutPropertyInput
@@ -10792,6 +10812,7 @@ export namespace Prisma {
     numberOfReviews?: number | null
     locationId: number
     managerCognitoId: string
+    isDeleted?: boolean
     leases?: LeaseUncheckedCreateNestedManyWithoutPropertyInput
     applications?: ApplicationUncheckedCreateNestedManyWithoutPropertyInput
     favoritedBy?: TenantUncheckedCreateNestedManyWithoutFavoritesInput
@@ -10816,6 +10837,7 @@ export namespace Prisma {
     postedDate?: DateTimeFieldUpdateOperationsInput | Date | string
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     location?: LocationUpdateOneRequiredWithoutPropertiesNestedInput
     manager?: ManagerUpdateOneRequiredWithoutManagedPropertiesNestedInput
     leases?: LeaseUpdateManyWithoutPropertyNestedInput
@@ -10845,6 +10867,7 @@ export namespace Prisma {
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     locationId?: IntFieldUpdateOperationsInput | number
     managerCognitoId?: StringFieldUpdateOperationsInput | string
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     leases?: LeaseUncheckedUpdateManyWithoutPropertyNestedInput
     applications?: ApplicationUncheckedUpdateManyWithoutPropertyNestedInput
     favoritedBy?: TenantUncheckedUpdateManyWithoutFavoritesNestedInput
@@ -10872,6 +10895,7 @@ export namespace Prisma {
     numberOfReviews?: number | null
     locationId: number
     managerCognitoId: string
+    isDeleted?: boolean
   }
 
   export type PropertyUpdateManyMutationInput = {
@@ -10892,6 +10916,7 @@ export namespace Prisma {
     postedDate?: DateTimeFieldUpdateOperationsInput | Date | string
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type PropertyUncheckedUpdateManyInput = {
@@ -10915,6 +10940,7 @@ export namespace Prisma {
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     locationId?: IntFieldUpdateOperationsInput | number
     managerCognitoId?: StringFieldUpdateOperationsInput | string
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type ManagerCreateInput = {
@@ -11475,6 +11501,7 @@ export namespace Prisma {
     numberOfReviews?: SortOrder
     locationId?: SortOrder
     managerCognitoId?: SortOrder
+    isDeleted?: SortOrder
   }
 
   export type PropertyAvgOrderByAggregateInput = {
@@ -11508,6 +11535,7 @@ export namespace Prisma {
     numberOfReviews?: SortOrder
     locationId?: SortOrder
     managerCognitoId?: SortOrder
+    isDeleted?: SortOrder
   }
 
   export type PropertyMinOrderByAggregateInput = {
@@ -11528,6 +11556,7 @@ export namespace Prisma {
     numberOfReviews?: SortOrder
     locationId?: SortOrder
     managerCognitoId?: SortOrder
+    isDeleted?: SortOrder
   }
 
   export type PropertySumOrderByAggregateInput = {
@@ -13232,6 +13261,7 @@ export namespace Prisma {
     postedDate?: Date | string
     averageRating?: number | null
     numberOfReviews?: number | null
+    isDeleted?: boolean
     location: LocationCreateNestedOneWithoutPropertiesInput
     leases?: LeaseCreateNestedManyWithoutPropertyInput
     applications?: ApplicationCreateNestedManyWithoutPropertyInput
@@ -13259,6 +13289,7 @@ export namespace Prisma {
     averageRating?: number | null
     numberOfReviews?: number | null
     locationId: number
+    isDeleted?: boolean
     leases?: LeaseUncheckedCreateNestedManyWithoutPropertyInput
     applications?: ApplicationUncheckedCreateNestedManyWithoutPropertyInput
     favoritedBy?: TenantUncheckedCreateNestedManyWithoutFavoritesInput
@@ -13315,6 +13346,7 @@ export namespace Prisma {
     numberOfReviews?: IntNullableFilter<"Property"> | number | null
     locationId?: IntFilter<"Property"> | number
     managerCognitoId?: StringFilter<"Property"> | string
+    isDeleted?: BoolFilter<"Property"> | boolean
   }
 
   export type PropertyCreateWithoutTenantsInput = {
@@ -13335,6 +13367,7 @@ export namespace Prisma {
     postedDate?: Date | string
     averageRating?: number | null
     numberOfReviews?: number | null
+    isDeleted?: boolean
     location: LocationCreateNestedOneWithoutPropertiesInput
     manager: ManagerCreateNestedOneWithoutManagedPropertiesInput
     leases?: LeaseCreateNestedManyWithoutPropertyInput
@@ -13363,6 +13396,7 @@ export namespace Prisma {
     numberOfReviews?: number | null
     locationId: number
     managerCognitoId: string
+    isDeleted?: boolean
     leases?: LeaseUncheckedCreateNestedManyWithoutPropertyInput
     applications?: ApplicationUncheckedCreateNestedManyWithoutPropertyInput
     favoritedBy?: TenantUncheckedCreateNestedManyWithoutFavoritesInput
@@ -13391,6 +13425,7 @@ export namespace Prisma {
     postedDate?: Date | string
     averageRating?: number | null
     numberOfReviews?: number | null
+    isDeleted?: boolean
     location: LocationCreateNestedOneWithoutPropertiesInput
     manager: ManagerCreateNestedOneWithoutManagedPropertiesInput
     leases?: LeaseCreateNestedManyWithoutPropertyInput
@@ -13419,6 +13454,7 @@ export namespace Prisma {
     numberOfReviews?: number | null
     locationId: number
     managerCognitoId: string
+    isDeleted?: boolean
     leases?: LeaseUncheckedCreateNestedManyWithoutPropertyInput
     applications?: ApplicationUncheckedCreateNestedManyWithoutPropertyInput
     tenants?: TenantUncheckedCreateNestedManyWithoutPropertiesInput
@@ -13575,6 +13611,7 @@ export namespace Prisma {
     postedDate?: Date | string
     averageRating?: number | null
     numberOfReviews?: number | null
+    isDeleted?: boolean
     manager: ManagerCreateNestedOneWithoutManagedPropertiesInput
     leases?: LeaseCreateNestedManyWithoutPropertyInput
     applications?: ApplicationCreateNestedManyWithoutPropertyInput
@@ -13602,6 +13639,7 @@ export namespace Prisma {
     averageRating?: number | null
     numberOfReviews?: number | null
     managerCognitoId: string
+    isDeleted?: boolean
     leases?: LeaseUncheckedCreateNestedManyWithoutPropertyInput
     applications?: ApplicationUncheckedCreateNestedManyWithoutPropertyInput
     favoritedBy?: TenantUncheckedCreateNestedManyWithoutFavoritesInput
@@ -13652,6 +13690,7 @@ export namespace Prisma {
     postedDate?: Date | string
     averageRating?: number | null
     numberOfReviews?: number | null
+    isDeleted?: boolean
     location: LocationCreateNestedOneWithoutPropertiesInput
     manager: ManagerCreateNestedOneWithoutManagedPropertiesInput
     leases?: LeaseCreateNestedManyWithoutPropertyInput
@@ -13680,6 +13719,7 @@ export namespace Prisma {
     numberOfReviews?: number | null
     locationId: number
     managerCognitoId: string
+    isDeleted?: boolean
     leases?: LeaseUncheckedCreateNestedManyWithoutPropertyInput
     favoritedBy?: TenantUncheckedCreateNestedManyWithoutFavoritesInput
     tenants?: TenantUncheckedCreateNestedManyWithoutPropertiesInput
@@ -13771,6 +13811,7 @@ export namespace Prisma {
     postedDate?: DateTimeFieldUpdateOperationsInput | Date | string
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     location?: LocationUpdateOneRequiredWithoutPropertiesNestedInput
     manager?: ManagerUpdateOneRequiredWithoutManagedPropertiesNestedInput
     leases?: LeaseUpdateManyWithoutPropertyNestedInput
@@ -13799,6 +13840,7 @@ export namespace Prisma {
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     locationId?: IntFieldUpdateOperationsInput | number
     managerCognitoId?: StringFieldUpdateOperationsInput | string
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     leases?: LeaseUncheckedUpdateManyWithoutPropertyNestedInput
     favoritedBy?: TenantUncheckedUpdateManyWithoutFavoritesNestedInput
     tenants?: TenantUncheckedUpdateManyWithoutPropertiesNestedInput
@@ -13886,6 +13928,7 @@ export namespace Prisma {
     postedDate?: Date | string
     averageRating?: number | null
     numberOfReviews?: number | null
+    isDeleted?: boolean
     location: LocationCreateNestedOneWithoutPropertiesInput
     manager: ManagerCreateNestedOneWithoutManagedPropertiesInput
     applications?: ApplicationCreateNestedManyWithoutPropertyInput
@@ -13914,6 +13957,7 @@ export namespace Prisma {
     numberOfReviews?: number | null
     locationId: number
     managerCognitoId: string
+    isDeleted?: boolean
     applications?: ApplicationUncheckedCreateNestedManyWithoutPropertyInput
     favoritedBy?: TenantUncheckedCreateNestedManyWithoutFavoritesInput
     tenants?: TenantUncheckedCreateNestedManyWithoutPropertiesInput
@@ -14034,6 +14078,7 @@ export namespace Prisma {
     postedDate?: DateTimeFieldUpdateOperationsInput | Date | string
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     location?: LocationUpdateOneRequiredWithoutPropertiesNestedInput
     manager?: ManagerUpdateOneRequiredWithoutManagedPropertiesNestedInput
     applications?: ApplicationUpdateManyWithoutPropertyNestedInput
@@ -14062,6 +14107,7 @@ export namespace Prisma {
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     locationId?: IntFieldUpdateOperationsInput | number
     managerCognitoId?: StringFieldUpdateOperationsInput | string
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     applications?: ApplicationUncheckedUpdateManyWithoutPropertyNestedInput
     favoritedBy?: TenantUncheckedUpdateManyWithoutFavoritesNestedInput
     tenants?: TenantUncheckedUpdateManyWithoutPropertiesNestedInput
@@ -14384,6 +14430,7 @@ export namespace Prisma {
     averageRating?: number | null
     numberOfReviews?: number | null
     locationId: number
+    isDeleted?: boolean
   }
 
   export type PropertyUpdateWithoutManagerInput = {
@@ -14404,6 +14451,7 @@ export namespace Prisma {
     postedDate?: DateTimeFieldUpdateOperationsInput | Date | string
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     location?: LocationUpdateOneRequiredWithoutPropertiesNestedInput
     leases?: LeaseUpdateManyWithoutPropertyNestedInput
     applications?: ApplicationUpdateManyWithoutPropertyNestedInput
@@ -14431,6 +14479,7 @@ export namespace Prisma {
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     locationId?: IntFieldUpdateOperationsInput | number
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     leases?: LeaseUncheckedUpdateManyWithoutPropertyNestedInput
     applications?: ApplicationUncheckedUpdateManyWithoutPropertyNestedInput
     favoritedBy?: TenantUncheckedUpdateManyWithoutFavoritesNestedInput
@@ -14457,6 +14506,7 @@ export namespace Prisma {
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     locationId?: IntFieldUpdateOperationsInput | number
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type ApplicationCreateManyTenantInput = {
@@ -14498,6 +14548,7 @@ export namespace Prisma {
     postedDate?: DateTimeFieldUpdateOperationsInput | Date | string
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     location?: LocationUpdateOneRequiredWithoutPropertiesNestedInput
     manager?: ManagerUpdateOneRequiredWithoutManagedPropertiesNestedInput
     leases?: LeaseUpdateManyWithoutPropertyNestedInput
@@ -14526,6 +14577,7 @@ export namespace Prisma {
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     locationId?: IntFieldUpdateOperationsInput | number
     managerCognitoId?: StringFieldUpdateOperationsInput | string
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     leases?: LeaseUncheckedUpdateManyWithoutPropertyNestedInput
     applications?: ApplicationUncheckedUpdateManyWithoutPropertyNestedInput
     favoritedBy?: TenantUncheckedUpdateManyWithoutFavoritesNestedInput
@@ -14552,6 +14604,7 @@ export namespace Prisma {
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     locationId?: IntFieldUpdateOperationsInput | number
     managerCognitoId?: StringFieldUpdateOperationsInput | string
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type PropertyUpdateWithoutFavoritedByInput = {
@@ -14572,6 +14625,7 @@ export namespace Prisma {
     postedDate?: DateTimeFieldUpdateOperationsInput | Date | string
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     location?: LocationUpdateOneRequiredWithoutPropertiesNestedInput
     manager?: ManagerUpdateOneRequiredWithoutManagedPropertiesNestedInput
     leases?: LeaseUpdateManyWithoutPropertyNestedInput
@@ -14600,6 +14654,7 @@ export namespace Prisma {
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     locationId?: IntFieldUpdateOperationsInput | number
     managerCognitoId?: StringFieldUpdateOperationsInput | string
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     leases?: LeaseUncheckedUpdateManyWithoutPropertyNestedInput
     applications?: ApplicationUncheckedUpdateManyWithoutPropertyNestedInput
     tenants?: TenantUncheckedUpdateManyWithoutPropertiesNestedInput
@@ -14626,6 +14681,7 @@ export namespace Prisma {
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     locationId?: IntFieldUpdateOperationsInput | number
     managerCognitoId?: StringFieldUpdateOperationsInput | string
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type ApplicationUpdateWithoutTenantInput = {
@@ -14711,6 +14767,7 @@ export namespace Prisma {
     postedDate?: DateTimeFieldUpdateOperationsInput | Date | string
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     manager?: ManagerUpdateOneRequiredWithoutManagedPropertiesNestedInput
     leases?: LeaseUpdateManyWithoutPropertyNestedInput
     applications?: ApplicationUpdateManyWithoutPropertyNestedInput
@@ -14738,6 +14795,7 @@ export namespace Prisma {
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     managerCognitoId?: StringFieldUpdateOperationsInput | string
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
     leases?: LeaseUncheckedUpdateManyWithoutPropertyNestedInput
     applications?: ApplicationUncheckedUpdateManyWithoutPropertyNestedInput
     favoritedBy?: TenantUncheckedUpdateManyWithoutFavoritesNestedInput
@@ -14764,6 +14822,7 @@ export namespace Prisma {
     averageRating?: number | null
     numberOfReviews?: number | null
     managerCognitoId: string
+    isDeleted?: boolean
   }
 
   export type PropertyUncheckedUpdateManyWithoutLocationInput = {
@@ -14786,6 +14845,7 @@ export namespace Prisma {
     averageRating?: NullableFloatFieldUpdateOperationsInput | number | null
     numberOfReviews?: NullableIntFieldUpdateOperationsInput | number | null
     managerCognitoId?: StringFieldUpdateOperationsInput | string
+    isDeleted?: BoolFieldUpdateOperationsInput | boolean
   }
 
   export type PaymentCreateManyLeaseInput = {

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -86,6 +86,7 @@ model Property {
   numberOfReviews   Int?         @default(0)
   locationId        Int
   managerCognitoId  String
+  isDeleted         Boolean      @default(false)
 
   location     Location      @relation(fields: [locationId], references: [id])
   manager      Manager       @relation(fields: [managerCognitoId], references: [cognitoId])

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -82,7 +82,7 @@ export const getManagerProperties = async (
   try {
     const { cognitoId } = req.params;
     const properties = await prisma.property.findMany({
-      where: { managerCognitoId: cognitoId },
+      where: { managerCognitoId: cognitoId, isDeleted: false },
       include: {
         location: true,
       },

--- a/server/src/routes/propertyRoutes.ts
+++ b/server/src/routes/propertyRoutes.ts
@@ -3,6 +3,8 @@ import {
   getProperties,
   getProperty,
   createProperty,
+  updateProperty,
+  softDeleteProperty,
 } from "../controllers/propertyControllers";
 import multer from "multer";
 import { authMiddleware } from "../middleware/authMiddleware";
@@ -20,5 +22,7 @@ router.post(
   upload.array("photos"),
   createProperty
 );
+router.put("/:id", authMiddleware(["manager"]), updateProperty);
+router.delete("/:id", authMiddleware(["manager"]), softDeleteProperty);
 
 export default router;


### PR DESCRIPTION
## Summary
- add `isDeleted` flag and soft delete endpoint for properties
- update RTK Query API for property edits and deletions with optimistic updates
- add inline property edit form for managers with rollback on failure

## Testing
- `npm run prisma:generate`
- `npm run build` (server)
- `npm test` (server) *(fails: Missing script "test")*
- `npm run build` (client)
- `npm test` (client) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a97d8eafb08328ae85d7c4d2c8dce7