### PR TITLE
Add S3 bucket configuration with policy and lifecycle controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ client/.env
 server/.env
 client/.next/
 node_modules
+
+# Terraform directories
+.terraform/

--- a/infrastructure/.terraform.lock.hcl
+++ b/infrastructure/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -1,0 +1,119 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "region" {
+  description = "AWS region for the S3 bucket"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "allowed_origin" {
+  description = "CORS allowed origin for browser uploads"
+  type        = string
+  default     = "*"
+}
+
+variable "upload_principal_arn" {
+  description = "ARN of the principal allowed to access the bucket"
+  type        = string
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_s3_bucket" "app_bucket" {
+  bucket = var.bucket_name
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT", "POST", "GET"]
+    allowed_origins = [var.allowed_origin]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}
+
+resource "aws_s3_bucket_versioning" "app_bucket_versioning" {
+  bucket = aws_s3_bucket.app_bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "app_bucket_lifecycle" {
+  bucket = aws_s3_bucket.app_bucket.id
+
+  rule {
+    id     = "manage-storage"
+    status = "Enabled"
+
+    filter {
+      prefix = ""
+    }
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    expiration {
+      days = 365
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {
+    sid = "AllowUploads"
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.upload_principal_arn]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject"
+    ]
+
+    resources = ["${aws_s3_bucket.app_bucket.arn}/*"]
+  }
+
+  statement {
+    sid = "AllowListBucket"
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.upload_principal_arn]
+    }
+
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.app_bucket.arn]
+  }
+}
+
+resource "aws_s3_bucket_policy" "app_bucket_policy" {
+  bucket = aws_s3_bucket.app_bucket.id
+  policy = data.aws_iam_policy_document.bucket_policy.json
+}


### PR DESCRIPTION
## Summary
- define Terraform module for S3 bucket
- restrict bucket policy to required actions
- enable browser upload CORS, versioning, and lifecycle management

## Testing
- `terraform validate`
- `npm test` (server) *(fails: Missing script "test")*
- `npm test` (client) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a97d8cf62483289da4c37ca813d0d9