### PR TITLE
feat: serve images via cloudfront

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -5,13 +5,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "example.com",
-        port: "",
-        pathname: "/**",
-      },
-      {
-        protocol: "https",
-        hostname: "*.amazonaws.com",
+        hostname: process.env.CLOUDFRONT_DOMAIN || "",
         port: "",
         pathname: "/**",
       },


### PR DESCRIPTION
## Summary
- route property image URLs through CloudFront during upload and when returning property data
- allow Next.js Image optimization for the CloudFront domain

## Testing
- `npm test` (client) *(fails: Missing script)*
- `npm test` (server) *(fails: Missing script)*
- `npm run build` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a97d8b94c08328ac557b88a0716ec8