### PR TITLE
feat: show amenity counts in search filters

### DIFF
--- a/client/src/app/(dashboard)/tenants/favorites/page.tsx
+++ b/client/src/app/(dashboard)/tenants/favorites/page.tsx
@@ -20,7 +20,7 @@ const Favorites = () => {
   );
 
   const {
-    data: favoriteProperties,
+    data: favoritesResult,
     isLoading,
     error,
   } = useGetPropertiesQuery(
@@ -38,7 +38,7 @@ const Favorites = () => {
         subtitle="Browse and manage your saved property listings"
       />
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-        {favoriteProperties?.map((property) => (
+        {favoritesResult?.properties?.map((property) => (
           <Card
             key={property.id}
             property={property}
@@ -49,7 +49,7 @@ const Favorites = () => {
           />
         ))}
       </div>
-      {(!favoriteProperties || favoriteProperties.length === 0) && (
+      {(!favoritesResult || favoritesResult.properties.length === 0) && (
         <p>You don&lsquo;t have any favorited properties</p>
       )}
     </div>

--- a/client/src/app/(nondashboard)/search/FiltersFull.tsx
+++ b/client/src/app/(nondashboard)/search/FiltersFull.tsx
@@ -8,7 +8,7 @@ import { cleanParams, cn, formatEnumString } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Search } from "lucide-react";
-import { AmenityIcons, PropertyTypeIcons } from "@/lib/constants";
+import { AmenityIcons, PropertyTypeIcons, AmenityEnum } from "@/lib/constants";
 import { Slider } from "@/components/ui/slider";
 import {
   Select,
@@ -18,6 +18,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { useGetPropertiesQuery } from "@/state/api";
 
 const FiltersFull = () => {
   const dispatch = useDispatch();
@@ -28,6 +30,9 @@ const FiltersFull = () => {
   const isFiltersFullOpen = useAppSelector(
     (state) => state.global.isFiltersFullOpen
   );
+
+  const { data: result } = useGetPropertiesQuery(localFilters);
+  const amenityCounts = result?.amenityCounts || {};
 
   const updateURL = debounce((newFilters: FiltersState) => {
     const cleanFilters = cleanParams(newFilters);
@@ -252,6 +257,9 @@ const FiltersFull = () => {
                 <Label className="hover:cursor-pointer">
                   {formatEnumString(amenity)}
                 </Label>
+                <Badge variant="secondary" className="ml-auto">
+                  {amenityCounts[amenity] ?? 0}
+                </Badge>
               </div>
             ))}
           </div>

--- a/client/src/app/(nondashboard)/search/Listings.tsx
+++ b/client/src/app/(nondashboard)/search/Listings.tsx
@@ -25,7 +25,7 @@ const Listings = () => {
   const filters = useAppSelector((state) => state.global.filters);
 
   const {
-    data: properties,
+    data: result,
     isLoading,
     isError,
   } = useGetPropertiesQuery(filters);
@@ -51,19 +51,19 @@ const Listings = () => {
   };
 
   if (isLoading) return <>Loading...</>;
-  if (isError || !properties) return <div>Failed to fetch properties</div>;
+  if (isError || !result) return <div>Failed to fetch properties</div>;
 
   return (
     <div className="w-full">
       <h3 className="text-sm px-4 font-bold">
-        {properties.length}{" "}
+        {result.properties.length}{" "}
         <span className="text-gray-700 font-normal">
           Places in {filters.location}
         </span>
       </h3>
       <div className="flex">
         <div className="p-4 w-full">
-          {properties?.map((property) =>
+          {result.properties?.map((property) =>
             viewMode === "grid" ? (
               <Card
                 key={property.id}

--- a/client/src/app/(nondashboard)/search/Map.tsx
+++ b/client/src/app/(nondashboard)/search/Map.tsx
@@ -12,13 +12,13 @@ const Map = () => {
   const mapContainerRef = useRef(null);
   const filters = useAppSelector((state) => state.global.filters);
   const {
-    data: properties,
+    data: result,
     isLoading,
     isError,
   } = useGetPropertiesQuery(filters);
 
   useEffect(() => {
-    if (isLoading || isError || !properties) return;
+    if (isLoading || isError || !result) return;
 
     const map = new mapboxgl.Map({
       container: mapContainerRef.current!,
@@ -27,7 +27,7 @@ const Map = () => {
       zoom: 9,
     });
 
-    properties.forEach((property) => {
+    result.properties.forEach((property) => {
       const marker = createPropertyMarker(property, map);
       const markerElement = marker.getElement();
       const path = markerElement.querySelector("path[fill='#3FB1CE']");
@@ -40,10 +40,10 @@ const Map = () => {
     resizeMap();
 
     return () => map.remove();
-  }, [isLoading, isError, properties, filters.coordinates]);
+  }, [isLoading, isError, result, filters.coordinates]);
 
   if (isLoading) return <>Loading...</>;
-  if (isError || !properties) return <div>Failed to fetch properties</div>;
+  if (isError || !result) return <div>Failed to fetch properties</div>;
 
   return (
     <div className="basis-5/12 grow relative rounded-xl">

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -77,7 +77,7 @@ export const api = createApi({
 
     // property related endpoints
     getProperties: build.query<
-      Property[],
+      { properties: Property[]; amenityCounts: Record<string, number> },
       Partial<FiltersState> & { favoriteIds?: number[] }
     >({
       query: (filters) => {
@@ -102,7 +102,10 @@ export const api = createApi({
       providesTags: (result) =>
         result
           ? [
-              ...result.map(({ id }) => ({ type: "Properties" as const, id })),
+              ...result.properties.map(({ id }) => ({
+                type: "Properties" as const,
+                id,
+              })),
               { type: "Properties", id: "LIST" },
             ]
           : [{ type: "Properties", id: "LIST" }],


### PR DESCRIPTION
## Summary
- aggregate amenity counts for property search results
- include amenity counts in properties API
- display amenity count badges in filter drawer

## Testing
- `npm test` (server) *(fails: Missing script)*
- `npm run build` (server)
- `npm test` (client) *(fails: Missing script)*
- `npm run lint` (client)


------
https://chatgpt.com/codex/tasks/task_e_68a97d89e8588328839cf13fb88e5d46