### PR TITLE
feat: map clustering with hover sync

### DIFF
--- a/client/src/app/(nondashboard)/search/Listings.tsx
+++ b/client/src/app/(nondashboard)/search/Listings.tsx
@@ -5,7 +5,8 @@ import {
   useGetTenantQuery,
   useRemoveFavoritePropertyMutation,
 } from "@/state/api";
-import { useAppSelector } from "@/state/redux";
+import { useAppDispatch, useAppSelector } from "@/state/redux";
+import { setHoveredPropertyId } from "@/state";
 import { Property } from "@/types/prismaTypes";
 import Card from "@/components/Card";
 import React from "react";
@@ -23,6 +24,10 @@ const Listings = () => {
   const [removeFavorite] = useRemoveFavoritePropertyMutation();
   const viewMode = useAppSelector((state) => state.global.viewMode);
   const filters = useAppSelector((state) => state.global.filters);
+  const hoveredPropertyId = useAppSelector(
+    (state) => state.global.hoveredPropertyId
+  );
+  const dispatch = useAppDispatch();
 
   const {
     data: properties,
@@ -63,35 +68,41 @@ const Listings = () => {
       </h3>
       <div className="flex">
         <div className="p-4 w-full">
-          {properties?.map((property) =>
-            viewMode === "grid" ? (
-              <Card
-                key={property.id}
-                property={property}
-                isFavorite={
-                  tenant?.favorites?.some(
-                    (fav: Property) => fav.id === property.id
-                  ) || false
-                }
-                onFavoriteToggle={() => handleFavoriteToggle(property.id)}
-                showFavoriteButton={!!authUser}
-                propertyLink={`/search/${property.id}`}
-              />
-            ) : (
-              <CardCompact
-                key={property.id}
-                property={property}
-                isFavorite={
-                  tenant?.favorites?.some(
-                    (fav: Property) => fav.id === property.id
-                  ) || false
-                }
-                onFavoriteToggle={() => handleFavoriteToggle(property.id)}
-                showFavoriteButton={!!authUser}
-                propertyLink={`/search/${property.id}`}
-              />
-            )
-          )}
+          {properties?.map((property) => (
+            <div
+              key={property.id}
+              onMouseEnter={() => dispatch(setHoveredPropertyId(property.id))}
+              onMouseLeave={() => dispatch(setHoveredPropertyId(null))}
+            >
+              {viewMode === "grid" ? (
+                <Card
+                  property={property}
+                  isFavorite={
+                    tenant?.favorites?.some(
+                      (fav: Property) => fav.id === property.id
+                    ) || false
+                  }
+                  onFavoriteToggle={() => handleFavoriteToggle(property.id)}
+                  showFavoriteButton={!!authUser}
+                  propertyLink={`/search/${property.id}`}
+                  isHighlighted={hoveredPropertyId === property.id}
+                />
+              ) : (
+                <CardCompact
+                  property={property}
+                  isFavorite={
+                    tenant?.favorites?.some(
+                      (fav: Property) => fav.id === property.id
+                    ) || false
+                  }
+                  onFavoriteToggle={() => handleFavoriteToggle(property.id)}
+                  showFavoriteButton={!!authUser}
+                  propertyLink={`/search/${property.id}`}
+                  isHighlighted={hoveredPropertyId === property.id}
+                />
+              )}
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/client/src/app/(nondashboard)/search/Map.tsx
+++ b/client/src/app/(nondashboard)/search/Map.tsx
@@ -1,49 +1,129 @@
 "use client";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
-import { useAppSelector } from "@/state/redux";
-import { useGetPropertiesQuery } from "@/state/api";
+import { useAppDispatch, useAppSelector } from "@/state/redux";
+import { useGetPropertyClustersQuery } from "@/state/api";
+import { setHoveredPropertyId } from "@/state";
 import { Property } from "@/types/prismaTypes";
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN as string;
 
 const Map = () => {
-  const mapContainerRef = useRef(null);
+  const mapContainerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<mapboxgl.Map | null>(null);
+  const propertyMarkersRef = useRef(new Map<number, mapboxgl.Marker>());
+  const clusterMarkersRef = useRef<mapboxgl.Marker[]>([]);
+  const dispatch = useAppDispatch();
   const filters = useAppSelector((state) => state.global.filters);
-  const {
-    data: properties,
-    isLoading,
-    isError,
-  } = useGetPropertiesQuery(filters);
+  const hoveredPropertyId = useAppSelector(
+    (state) => state.global.hoveredPropertyId
+  );
+  const [bbox, setBbox] = useState<number[] | null>(null);
+  const [zoom, setZoom] = useState<number>(9);
+
+  const { data: clusters } = useGetPropertyClustersQuery(
+    bbox ? { bbox, zoom } : ({} as any),
+    { skip: !bbox }
+  );
 
   useEffect(() => {
-    if (isLoading || isError || !properties) return;
+    if (mapRef.current || !mapContainerRef.current) return;
 
-    const map = new mapboxgl.Map({
-      container: mapContainerRef.current!,
+    mapRef.current = new mapboxgl.Map({
+      container: mapContainerRef.current,
       style: "mapbox://styles/majesticglue/cm6u301pq008b01sl7yk1cnvb",
       center: filters.coordinates || [-74.5, 40],
       zoom: 9,
     });
 
-    properties.forEach((property) => {
-      const marker = createPropertyMarker(property, map);
-      const markerElement = marker.getElement();
-      const path = markerElement.querySelector("path[fill='#3FB1CE']");
-      if (path) path.setAttribute("fill", "#000000");
-    });
-
-    const resizeMap = () => {
-      if (map) setTimeout(() => map.resize(), 700);
+    const updateBounds = () => {
+      if (!mapRef.current) return;
+      const bounds = mapRef.current.getBounds();
+      setBbox([
+        bounds.getWest(),
+        bounds.getSouth(),
+        bounds.getEast(),
+        bounds.getNorth(),
+      ]);
+      setZoom(Math.round(mapRef.current.getZoom()));
     };
-    resizeMap();
 
-    return () => map.remove();
-  }, [isLoading, isError, properties, filters.coordinates]);
+    mapRef.current.on("load", updateBounds);
+    mapRef.current.on("moveend", updateBounds);
+  }, [filters.coordinates]);
 
-  if (isLoading) return <>Loading...</>;
-  if (isError || !properties) return <div>Failed to fetch properties</div>;
+  useEffect(() => {
+    if (!clusters || !mapRef.current) return;
+
+    propertyMarkersRef.current.forEach((m) => m.remove());
+    propertyMarkersRef.current.clear();
+    clusterMarkersRef.current.forEach((m) => m.remove());
+    clusterMarkersRef.current = [];
+
+    clusters.forEach((feature: any) => {
+      const [lng, lat] = feature.geometry.coordinates;
+      if (feature.properties.cluster) {
+        const el = document.createElement("div");
+        el.className =
+          "flex items-center justify-center bg-blue-500 text-white rounded-full";
+        const size = 30;
+        el.style.width = `${size}px`;
+        el.style.height = `${size}px`;
+        el.textContent = feature.properties.point_count;
+        const marker = new mapboxgl.Marker({ element: el })
+          .setLngLat([lng, lat])
+          .addTo(mapRef.current!);
+        clusterMarkersRef.current.push(marker);
+        el.addEventListener("click", () => {
+          mapRef.current!.easeTo({
+            center: [lng, lat],
+            zoom: mapRef.current!.getZoom() + 2,
+          });
+        });
+      } else {
+        const property: Property = feature.properties;
+        const el = document.createElement("div");
+        el.style.width = "20px";
+        el.style.height = "20px";
+        el.style.borderRadius = "50%";
+        el.style.backgroundColor = "#000";
+        const marker = new mapboxgl.Marker(el)
+          .setLngLat([lng, lat])
+          .setPopup(
+            new mapboxgl.Popup().setHTML(
+              `
+              <div class="marker-popup">
+                <div class="marker-popup-image"></div>
+                <div>
+                  <a href="/search/${property.id}" target="_blank" class="marker-popup-title">${property.name}</a>
+                  <p class="marker-popup-price">
+                    $${property.pricePerMonth}
+                    <span class="marker-popup-price-unit"> / month</span>
+                  </p>
+                </div>
+              </div>
+              `
+            )
+          )
+          .addTo(mapRef.current!);
+        propertyMarkersRef.current.set(property.id, marker);
+        el.addEventListener("mouseenter", () =>
+          dispatch(setHoveredPropertyId(property.id))
+        );
+        el.addEventListener("mouseleave", () =>
+          dispatch(setHoveredPropertyId(null))
+        );
+      }
+    });
+  }, [clusters, dispatch]);
+
+  useEffect(() => {
+    propertyMarkersRef.current.forEach((marker, id) => {
+      const el = marker.getElement() as HTMLElement;
+      el.style.backgroundColor = id === hoveredPropertyId ? "#2563eb" : "#000";
+    });
+  }, [hoveredPropertyId]);
 
   return (
     <div className="basis-5/12 grow relative rounded-xl">
@@ -57,32 +137,6 @@ const Map = () => {
       />
     </div>
   );
-};
-
-const createPropertyMarker = (property: Property, map: mapboxgl.Map) => {
-  const marker = new mapboxgl.Marker()
-    .setLngLat([
-      property.location.coordinates.longitude,
-      property.location.coordinates.latitude,
-    ])
-    .setPopup(
-      new mapboxgl.Popup().setHTML(
-        `
-        <div class="marker-popup">
-          <div class="marker-popup-image"></div>
-          <div>
-            <a href="/search/${property.id}" target="_blank" class="marker-popup-title">${property.name}</a>
-            <p class="marker-popup-price">
-              $${property.pricePerMonth}
-              <span class="marker-popup-price-unit"> / month</span>
-            </p>
-          </div>
-        </div>
-        `
-      )
-    )
-    .addTo(map);
-  return marker;
 };
 
 export default Map;

--- a/client/src/components/Card.tsx
+++ b/client/src/components/Card.tsx
@@ -9,13 +9,18 @@ const Card = ({
   onFavoriteToggle,
   showFavoriteButton = true,
   propertyLink,
+  isHighlighted = false,
 }: CardProps) => {
   const [imgSrc, setImgSrc] = useState(
     property.photoUrls?.[0] || "/placeholder.jpg"
   );
 
   return (
-    <div className="bg-white rounded-xl overflow-hidden shadow-lg w-full mb-5">
+    <div
+      className={`bg-white rounded-xl overflow-hidden shadow-lg w-full mb-5 ${
+        isHighlighted ? "ring-2 ring-blue-500" : ""
+      }`}
+    >
       <div className="relative">
         <div className="w-full h-48 relative">
           <Image

--- a/client/src/components/CardCompact.tsx
+++ b/client/src/components/CardCompact.tsx
@@ -9,13 +9,18 @@ const CardCompact = ({
   onFavoriteToggle,
   showFavoriteButton = true,
   propertyLink,
+  isHighlighted = false,
 }: CardCompactProps) => {
   const [imgSrc, setImgSrc] = useState(
     property.photoUrls?.[0] || "/placeholder.jpg"
   );
 
   return (
-    <div className="bg-white rounded-xl overflow-hidden shadow-lg w-full flex h-40 mb-5">
+    <div
+      className={`bg-white rounded-xl overflow-hidden shadow-lg w-full flex h-40 mb-5 ${
+        isHighlighted ? "ring-2 ring-blue-500" : ""
+      }`}
+    >
       <div className="relative w-1/3">
         <Image
           src={imgSrc}

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -113,6 +113,16 @@ export const api = createApi({
       },
     }),
 
+    getPropertyClusters: build.query<
+      any[],
+      { bbox: number[]; zoom: number }
+    >({
+      query: ({ bbox, zoom }) => ({
+        url: "properties/clusters",
+        params: { bbox: bbox.join(","), zoom },
+      }),
+    }),
+
     getProperty: build.query<Property, number>({
       query: (id) => `properties/${id}`,
       providesTags: (result, error, id) => [{ type: "PropertyDetails", id }],
@@ -356,6 +366,7 @@ export const {
   useUpdateTenantSettingsMutation,
   useUpdateManagerSettingsMutation,
   useGetPropertiesQuery,
+  useGetPropertyClustersQuery,
   useGetPropertyQuery,
   useGetCurrentResidencesQuery,
   useGetManagerPropertiesQuery,

--- a/client/src/state/index.ts
+++ b/client/src/state/index.ts
@@ -16,6 +16,7 @@ interface InitialStateTypes {
   filters: FiltersState;
   isFiltersFullOpen: boolean;
   viewMode: "grid" | "list";
+  hoveredPropertyId: number | null;
 }
 
 export const initialState: InitialStateTypes = {
@@ -32,6 +33,7 @@ export const initialState: InitialStateTypes = {
   },
   isFiltersFullOpen: false,
   viewMode: "grid",
+  hoveredPropertyId: null,
 };
 
 export const globalSlice = createSlice({
@@ -47,10 +49,20 @@ export const globalSlice = createSlice({
     setViewMode: (state, action: PayloadAction<"grid" | "list">) => {
       state.viewMode = action.payload;
     },
+    setHoveredPropertyId: (
+      state,
+      action: PayloadAction<number | null>
+    ) => {
+      state.hoveredPropertyId = action.payload;
+    },
   },
 });
 
-export const { setFilters, toggleFiltersFullOpen, setViewMode } =
-  globalSlice.actions;
+export const {
+  setFilters,
+  toggleFiltersFullOpen,
+  setViewMode,
+  setHoveredPropertyId,
+} = globalSlice.actions;
 
 export default globalSlice.reducer;

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -101,6 +101,7 @@ declare global {
     onFavoriteToggle: () => void;
     showFavoriteButton?: boolean;
     propertyLink?: string;
+    isHighlighted?: boolean;
   }
 
   interface CardCompactProps {
@@ -109,6 +110,7 @@ declare global {
     onFavoriteToggle: () => void;
     showFavoriteButton?: boolean;
     propertyLink?: string;
+    isHighlighted?: boolean;
   }
 
   interface HeaderProps {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,6 +23,7 @@
         "morgan": "^1.10.0",
         "multer": "^1.4.5-lts.1",
         "prisma": "^6.3.0",
+        "supercluster": "^8.0.1",
         "uuid": "^11.0.5"
       },
       "devDependencies": {
@@ -31,6 +32,7 @@
         "@types/morgan": "^1.9.9",
         "@types/multer": "^1.4.12",
         "@types/node": "^22.13.0",
+        "@types/supercluster": "^5.0.3",
         "@types/terraformer__wkt": "^2.0.3",
         "@types/uuid": "^10.0.0",
         "concurrently": "^9.1.2",
@@ -1965,6 +1967,16 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/supercluster": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-5.0.3.tgz",
+      "integrity": "sha512-XMSqQEr7YDuNtFwSgaHHOjsbi0ZGL62V9Js4CW45RBuRYlNWSW/KDqN+RFFE7HdHcGhJPtN0klKvw06r9Kg7rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/terraformer__wkt": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/terraformer__wkt/-/terraformer__wkt-2.0.3.tgz",
@@ -3353,6 +3365,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -4470,6 +4488,15 @@
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "license": "MIT"
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
     },
     "node_modules/supports-color": {
       "version": "8.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,8 @@
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
     "prisma": "^6.3.0",
-    "uuid": "^11.0.5"
+    "uuid": "^11.0.5",
+    "supercluster": "^8.0.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
@@ -39,6 +40,7 @@
     "@types/node": "^22.13.0",
     "@types/terraformer__wkt": "^2.0.3",
     "@types/uuid": "^10.0.0",
+    "@types/supercluster": "^5.0.3",
     "concurrently": "^9.1.2",
     "nodemon": "^3.1.9",
     "rimraf": "^6.0.1",

--- a/server/src/routes/propertyRoutes.ts
+++ b/server/src/routes/propertyRoutes.ts
@@ -3,6 +3,7 @@ import {
   getProperties,
   getProperty,
   createProperty,
+  getPropertyClusters,
 } from "../controllers/propertyControllers";
 import multer from "multer";
 import { authMiddleware } from "../middleware/authMiddleware";
@@ -13,6 +14,7 @@ const upload = multer({ storage: storage });
 const router = express.Router();
 
 router.get("/", getProperties);
+router.get("/clusters", getPropertyClusters);
 router.get("/:id", getProperty);
 router.post(
   "/",


### PR DESCRIPTION
## Summary
- add server endpoint for property clusters
- show clustered markers on Mapbox map
- highlight markers and listings on synchronized hover

## Testing
- `npm --prefix server run build`
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a97d88c4488328bc823f54dfecb137