### PR TITLE
feat: validate API payloads with Zod

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,7 +23,8 @@
         "morgan": "^1.10.0",
         "multer": "^1.4.5-lts.1",
         "prisma": "^6.3.0",
-        "uuid": "^11.0.5"
+        "uuid": "^11.0.5",
+        "zod": "^3.24.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -4911,6 +4912,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,8 @@
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
     "prisma": "^6.3.0",
-    "uuid": "^11.0.5"
+    "uuid": "^11.0.5",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
+import {
+  createApplicationSchema,
+  updateApplicationStatusSchema,
+} from "../dto/application.dto";
 
 const prisma = new PrismaClient();
 
@@ -88,6 +92,11 @@ export const createApplication = async (
   res: Response
 ): Promise<void> => {
   try {
+    const parseResult = createApplicationSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      res.status(400).json({ errors: parseResult.error.flatten() });
+      return;
+    }
     const {
       applicationDate,
       status,
@@ -97,7 +106,7 @@ export const createApplication = async (
       email,
       phoneNumber,
       message,
-    } = req.body;
+    } = parseResult.data;
 
     const property = await prisma.property.findUnique({
       where: { id: propertyId },
@@ -171,7 +180,12 @@ export const updateApplicationStatus = async (
 ): Promise<void> => {
   try {
     const { id } = req.params;
-    const { status } = req.body;
+    const parseResult = updateApplicationStatusSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      res.status(400).json({ errors: parseResult.error.flatten() });
+      return;
+    }
+    const { status } = parseResult.data;
     console.log("status:", status);
 
     const application = await prisma.application.findUnique({

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -1,6 +1,10 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
+import {
+  createManagerSchema,
+  updateManagerSchema,
+} from "../dto/manager.dto";
 
 const prisma = new PrismaClient();
 
@@ -31,7 +35,12 @@ export const createManager = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId, name, email, phoneNumber } = req.body;
+    const parseResult = createManagerSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      res.status(400).json({ errors: parseResult.error.flatten() });
+      return;
+    }
+    const { cognitoId, name, email, phoneNumber } = parseResult.data;
 
     const manager = await prisma.manager.create({
       data: {
@@ -56,7 +65,12 @@ export const updateManager = async (
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
-    const { name, email, phoneNumber } = req.body;
+    const parseResult = updateManagerSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      res.status(400).json({ errors: parseResult.error.flatten() });
+      return;
+    }
+    const { name, email, phoneNumber } = parseResult.data;
 
     const updateManager = await prisma.manager.update({
       where: { cognitoId },

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -1,6 +1,10 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
 import { wktToGeoJSON } from "@terraformer/wkt";
+import {
+  createTenantSchema,
+  updateTenantSchema,
+} from "../dto/tenant.dto";
 
 const prisma = new PrismaClient();
 
@@ -31,7 +35,12 @@ export const createTenant = async (
   res: Response
 ): Promise<void> => {
   try {
-    const { cognitoId, name, email, phoneNumber } = req.body;
+    const parseResult = createTenantSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      res.status(400).json({ errors: parseResult.error.flatten() });
+      return;
+    }
+    const { cognitoId, name, email, phoneNumber } = parseResult.data;
 
     const tenant = await prisma.tenant.create({
       data: {
@@ -56,7 +65,12 @@ export const updateTenant = async (
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
-    const { name, email, phoneNumber } = req.body;
+    const parseResult = updateTenantSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      res.status(400).json({ errors: parseResult.error.flatten() });
+      return;
+    }
+    const { name, email, phoneNumber } = parseResult.data;
 
     const updateTenant = await prisma.tenant.update({
       where: { cognitoId },

--- a/server/src/dto/application.dto.ts
+++ b/server/src/dto/application.dto.ts
@@ -1,0 +1,22 @@
+import { ApplicationStatus } from "@prisma/client";
+import { z } from "zod";
+
+export const createApplicationSchema = z.object({
+  applicationDate: z.string().or(z.date()),
+  status: z.nativeEnum(ApplicationStatus),
+  propertyId: z.coerce.number(),
+  tenantCognitoId: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+  phoneNumber: z.string(),
+  message: z.string().optional(),
+});
+
+export const updateApplicationStatusSchema = z.object({
+  status: z.nativeEnum(ApplicationStatus),
+});
+
+export type CreateApplicationDto = z.infer<typeof createApplicationSchema>;
+export type UpdateApplicationStatusDto = z.infer<
+  typeof updateApplicationStatusSchema
+>;

--- a/server/src/dto/manager.dto.ts
+++ b/server/src/dto/manager.dto.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const createManagerSchema = z.object({
+  cognitoId: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+  phoneNumber: z.string(),
+});
+
+export const updateManagerSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  phoneNumber: z.string(),
+});
+
+export type CreateManagerDto = z.infer<typeof createManagerSchema>;
+export type UpdateManagerDto = z.infer<typeof updateManagerSchema>;

--- a/server/src/dto/tenant.dto.ts
+++ b/server/src/dto/tenant.dto.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const createTenantSchema = z.object({
+  cognitoId: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+  phoneNumber: z.string(),
+});
+
+export const updateTenantSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  phoneNumber: z.string(),
+});
+
+export type CreateTenantDto = z.infer<typeof createTenantSchema>;
+export type UpdateTenantDto = z.infer<typeof updateTenantSchema>;


### PR DESCRIPTION
## Summary
- add zod dependency and DTO schemas for applications, managers, and tenants
- enforce request body validation in related controllers with 400 errors on failure

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a97d8297788328bc96a2499cc9360c