### PR TITLE
feat: add soft delete fields and filters

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -86,9 +86,10 @@ model Property {
   numberOfReviews   Int?         @default(0)
   locationId        Int
   managerCognitoId  String
+  deletedAt         DateTime?
 
-  location     Location      @relation(fields: [locationId], references: [id])
-  manager      Manager       @relation(fields: [managerCognitoId], references: [cognitoId])
+  location     Location      @relation(fields: [locationId], references: [id], onDelete: Cascade)
+  manager      Manager       @relation(fields: [managerCognitoId], references: [cognitoId], onDelete: Cascade)
   leases       Lease[]
   applications Application[]
   favoritedBy  Tenant[]      @relation("TenantFavorites")
@@ -101,6 +102,7 @@ model Manager {
   name        String
   email       String
   phoneNumber String
+  deletedAt   DateTime?
 
   managedProperties Property[]
 }
@@ -111,6 +113,7 @@ model Tenant {
   name        String
   email       String
   phoneNumber String
+  deletedAt   DateTime?
 
   properties   Property[]    @relation("TenantProperties")
   favorites    Property[]    @relation("TenantFavorites")
@@ -126,6 +129,7 @@ model Location {
   country     String
   postalCode  String
   coordinates Unsupported("geography(Point, 4326)")
+  deletedAt   DateTime?
 
   properties Property[]
 }
@@ -141,10 +145,11 @@ model Application {
   phoneNumber     String
   message         String?
   leaseId         Int?              @unique
+  deletedAt       DateTime?
 
-  property Property @relation(fields: [propertyId], references: [id])
-  tenant   Tenant   @relation(fields: [tenantCognitoId], references: [cognitoId])
-  lease    Lease?   @relation(fields: [leaseId], references: [id])
+  property Property @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+  tenant   Tenant   @relation(fields: [tenantCognitoId], references: [cognitoId], onDelete: Cascade)
+  lease    Lease?   @relation(fields: [leaseId], references: [id], onDelete: Cascade)
 }
 
 model Lease {
@@ -155,9 +160,10 @@ model Lease {
   deposit         Float
   propertyId      Int
   tenantCognitoId String
+  deletedAt       DateTime?
 
-  property    Property     @relation(fields: [propertyId], references: [id])
-  tenant      Tenant       @relation(fields: [tenantCognitoId], references: [cognitoId])
+  property    Property     @relation(fields: [propertyId], references: [id], onDelete: Cascade)
+  tenant      Tenant       @relation(fields: [tenantCognitoId], references: [cognitoId], onDelete: Cascade)
   application Application?
   payments    Payment[]
 }
@@ -170,6 +176,7 @@ model Payment {
   paymentDate   DateTime
   paymentStatus PaymentStatus
   leaseId       Int
+  deletedAt     DateTime?
 
-  lease Lease @relation(fields: [leaseId], references: [id])
+  lease Lease @relation(fields: [leaseId], references: [id], onDelete: Cascade)
 }

--- a/server/src/controllers/applicationControllers.ts
+++ b/server/src/controllers/applicationControllers.ts
@@ -10,16 +10,15 @@ export const listApplications = async (
   try {
     const { userId, userType } = req.query;
 
-    let whereClause = {};
+    let whereClause: any = { deletedAt: null };
 
     if (userId && userType) {
       if (userType === "tenant") {
-        whereClause = { tenantCognitoId: String(userId) };
+        whereClause.tenantCognitoId = String(userId);
       } else if (userType === "manager") {
-        whereClause = {
-          property: {
-            managerCognitoId: String(userId),
-          },
+        whereClause.property = {
+          managerCognitoId: String(userId),
+          deletedAt: null,
         };
       }
     }
@@ -99,8 +98,8 @@ export const createApplication = async (
       message,
     } = req.body;
 
-    const property = await prisma.property.findUnique({
-      where: { id: propertyId },
+    const property = await prisma.property.findFirst({
+      where: { id: propertyId, deletedAt: null },
       select: { pricePerMonth: true, securityDeposit: true },
     });
 
@@ -174,8 +173,8 @@ export const updateApplicationStatus = async (
     const { status } = req.body;
     console.log("status:", status);
 
-    const application = await prisma.application.findUnique({
-      where: { id: Number(id) },
+    const application = await prisma.application.findFirst({
+      where: { id: Number(id), deletedAt: null },
       include: {
         property: true,
         tenant: true,
@@ -230,14 +229,14 @@ export const updateApplicationStatus = async (
     }
 
     // Respond with the updated application details
-    const updatedApplication = await prisma.application.findUnique({
-      where: { id: Number(id) },
-      include: {
-        property: true,
-        tenant: true,
-        lease: true,
-      },
-    });
+      const updatedApplication = await prisma.application.findFirst({
+        where: { id: Number(id), deletedAt: null },
+        include: {
+          property: true,
+          tenant: true,
+          lease: true,
+        },
+      });
 
     res.json(updatedApplication);
   } catch (error: any) {

--- a/server/src/controllers/leaseControllers.ts
+++ b/server/src/controllers/leaseControllers.ts
@@ -6,6 +6,7 @@ const prisma = new PrismaClient();
 export const getLeases = async (req: Request, res: Response): Promise<void> => {
   try {
     const leases = await prisma.lease.findMany({
+      where: { deletedAt: null },
       include: {
         tenant: true,
         property: true,
@@ -26,7 +27,7 @@ export const getLeasePayments = async (
   try {
     const { id } = req.params;
     const payments = await prisma.payment.findMany({
-      where: { leaseId: Number(id) },
+      where: { leaseId: Number(id), deletedAt: null },
     });
     res.json(payments);
   } catch (error: any) {

--- a/server/src/controllers/managerControllers.ts
+++ b/server/src/controllers/managerControllers.ts
@@ -10,8 +10,8 @@ export const getManager = async (
 ): Promise<void> => {
   try {
     const { cognitoId } = req.params;
-    const manager = await prisma.manager.findUnique({
-      where: { cognitoId },
+    const manager = await prisma.manager.findFirst({
+      where: { cognitoId, deletedAt: null },
     });
 
     if (manager) {
@@ -82,7 +82,7 @@ export const getManagerProperties = async (
   try {
     const { cognitoId } = req.params;
     const properties = await prisma.property.findMany({
-      where: { managerCognitoId: cognitoId },
+      where: { managerCognitoId: cognitoId, deletedAt: null },
       include: {
         location: true,
       },

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -32,7 +32,9 @@ export const getProperties = async (
       longitude,
     } = req.query;
 
-    let whereConditions: Prisma.Sql[] = [];
+    let whereConditions: Prisma.Sql[] = [
+      Prisma.sql`p."deletedAt" IS NULL`
+    ];
 
     if (favoriteIds) {
       const favoriteIdsArray = (favoriteIds as string).split(",").map(Number);
@@ -156,8 +158,8 @@ export const getProperty = async (
 ): Promise<void> => {
   try {
     const { id } = req.params;
-    const property = await prisma.property.findUnique({
-      where: { id: Number(id) },
+    const property = await prisma.property.findFirst({
+      where: { id: Number(id), deletedAt: null },
       include: {
         location: true,
       },

--- a/server/src/controllers/tenantControllers.ts
+++ b/server/src/controllers/tenantControllers.ts
@@ -7,8 +7,8 @@ const prisma = new PrismaClient();
 export const getTenant = async (req: Request, res: Response): Promise<void> => {
   try {
     const { cognitoId } = req.params;
-    const tenant = await prisma.tenant.findUnique({
-      where: { cognitoId },
+    const tenant = await prisma.tenant.findFirst({
+      where: { cognitoId, deletedAt: null },
       include: {
         favorites: true,
       },
@@ -82,7 +82,7 @@ export const getCurrentResidences = async (
   try {
     const { cognitoId } = req.params;
     const properties = await prisma.property.findMany({
-      where: { tenants: { some: { cognitoId } } },
+      where: { tenants: { some: { cognitoId } }, deletedAt: null },
       include: {
         location: true,
       },
@@ -124,8 +124,8 @@ export const addFavoriteProperty = async (
 ): Promise<void> => {
   try {
     const { cognitoId, propertyId } = req.params;
-    const tenant = await prisma.tenant.findUnique({
-      where: { cognitoId },
+    const tenant = await prisma.tenant.findFirst({
+      where: { cognitoId, deletedAt: null },
       include: { favorites: true },
     });
 


### PR DESCRIPTION
## Summary
- allow soft deletion across key models with new `deletedAt` fields
- filter out soft-deleted records in API controllers
- cascade related records on delete in Prisma schema

## Testing
- `npx prisma generate`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a97d818f8c832880b8f2bccc763285