### PR TITLE
Use PostGIS geometry with radius filtering

### DIFF
--- a/server/prisma/migrations/20250207120000_geometry_location/migration.sql
+++ b/server/prisma/migrations/20250207120000_geometry_location/migration.sql
@@ -1,0 +1,9 @@
+-- Alter Location.coordinates to geometry and add spatial index
+ALTER TABLE "Location"
+    ALTER COLUMN "coordinates"
+    TYPE geometry(Point, 4326)
+    USING ST_SetSRID("coordinates"::geometry, 4326);
+
+CREATE INDEX IF NOT EXISTS "Location_coordinates_idx"
+    ON "Location"
+    USING GIST ("coordinates");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -125,9 +125,11 @@ model Location {
   state       String
   country     String
   postalCode  String
-  coordinates Unsupported("geography(Point, 4326)")
+  coordinates Unsupported("geometry(Point, 4326)")
 
   properties Property[]
+
+  @@index([coordinates], type: Gist)
 }
 
 model Application {

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -30,6 +30,7 @@ export const getProperties = async (
       availableFrom,
       latitude,
       longitude,
+      radius,
     } = req.query;
 
     let whereConditions: Prisma.Sql[] = [];
@@ -101,17 +102,16 @@ export const getProperties = async (
       }
     }
 
-    if (latitude && longitude) {
+    if (latitude && longitude && radius) {
       const lat = parseFloat(latitude as string);
       const lng = parseFloat(longitude as string);
-      const radiusInKilometers = 1000;
-      const degrees = radiusInKilometers / 111; // Converts kilometers to degrees
+      const radiusInMeters = parseFloat(radius as string) * 1000;
 
       whereConditions.push(
         Prisma.sql`ST_DWithin(
-          l.coordinates::geometry,
-          ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326),
-          ${degrees}
+          l.coordinates::geography,
+          ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326)::geography,
+          ${radiusInMeters}
         )`
       );
     }


### PR DESCRIPTION
## Summary
- store property coordinates in geometry columns with a spatial index
- enable property search within a radius using ST_DWithin

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run prisma:generate`


------
https://chatgpt.com/codex/tasks/task_e_68a97d85cebc83288b1f28c9920f5b30