### PR TITLE
Fetch property images for listing preview

### DIFF
--- a/client/src/app/(nondashboard)/search/[id]/ImagePreviews.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/ImagePreviews.tsx
@@ -5,19 +5,24 @@ import Image from "next/image";
 import React, { useState } from "react";
 
 const ImagePreviews = ({ images }: ImagePreviewsProps) => {
+  const imageList = images.length > 0 ? images : ["/placeholder.jpg"];
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
   const handlePrev = () => {
-    setCurrentImageIndex((prev) => (prev === 0 ? images.length - 1 : prev - 1));
+    setCurrentImageIndex((prev) =>
+      prev === 0 ? imageList.length - 1 : prev - 1
+    );
   };
 
   const handleNext = () => {
-    setCurrentImageIndex((prev) => (prev === images.length - 1 ? 0 : prev + 1));
+    setCurrentImageIndex((prev) =>
+      prev === imageList.length - 1 ? 0 : prev + 1
+    );
   };
 
   return (
     <div className="relative h-[450px] w-full">
-      {images.map((image, index) => (
+      {imageList.map((image, index) => (
         <div
           key={image}
           className={`absolute inset-0 transition-opacity duration-500 ease-in-out ${

--- a/client/src/app/(nondashboard)/search/[id]/PropertyOverview.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/PropertyOverview.tsx
@@ -7,7 +7,16 @@ const PropertyOverview = ({ propertyId }: PropertyOverviewProps) => {
     data: property,
     isError,
     isLoading,
-  } = useGetPropertyQuery(propertyId);
+  } = useGetPropertyQuery(propertyId, {
+    // explicitly include photo URLs so other components can access them
+    selectFromResult: ({ data, isError, isLoading }) => ({
+      data: data
+        ? { ...data, photoUrls: data.photoUrls ?? [] }
+        : undefined,
+      isError,
+      isLoading,
+    }),
+  });
 
   if (isLoading) return <>Loading...</>;
   if (isError || !property) {

--- a/client/src/app/(nondashboard)/search/[id]/page.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useGetAuthUserQuery } from "@/state/api";
+import { useGetAuthUserQuery, useGetPropertyQuery } from "@/state/api";
 import { useParams } from "next/navigation";
 import React, { useState } from "react";
 import ImagePreviews from "./ImagePreviews";
@@ -15,12 +15,13 @@ const SingleListing = () => {
   const propertyId = Number(id);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { data: authUser } = useGetAuthUserQuery();
+  const { data: photoUrls = [] } = useGetPropertyQuery(propertyId, {
+    selectFromResult: ({ data }) => ({ data: data?.photoUrls ?? [] }),
+  });
 
   return (
     <div>
-      <ImagePreviews
-        images={["/singlelisting-2.jpg", "/singlelisting-3.jpg"]}
-      />
+      <ImagePreviews images={photoUrls} />
       <div className="flex flex-col md:flex-row justify-center gap-10 mx-10 md:w-2/3 md:mx-auto mt-16 mb-8">
         <div className="order-2 md:order-1">
           <PropertyOverview propertyId={propertyId} />


### PR DESCRIPTION
## Summary
- include photo URLs when retrieving property details
- display fetched photo URLs on listing page
- show placeholder when a property has no photos

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab451745e483288ba819de2524a604