### PR TITLE
Improve property listing and map error states

### DIFF
--- a/client/src/app/(nondashboard)/search/Listings.tsx
+++ b/client/src/app/(nondashboard)/search/Listings.tsx
@@ -10,6 +10,8 @@ import { Property } from "@/types/prismaTypes";
 import Card from "@/components/Card";
 import React from "react";
 import CardCompact from "@/components/CardCompact";
+import Loading from "@/components/Loading";
+import { Button } from "@/components/ui/button";
 
 const Listings = () => {
   const { data: authUser } = useGetAuthUserQuery();
@@ -28,6 +30,7 @@ const Listings = () => {
     data: properties,
     isLoading,
     isError,
+    refetch,
   } = useGetPropertiesQuery(filters);
 
   const handleFavoriteToggle = async (propertyId: number) => {
@@ -50,8 +53,18 @@ const Listings = () => {
     }
   };
 
-  if (isLoading) return <>Loading...</>;
-  if (isError || !properties) return <div>Failed to fetch properties</div>;
+  if (isLoading) return <Loading />;
+  if (isError)
+    return (
+      <div className="p-4 flex flex-col items-center gap-2">
+        <div>Failed to fetch properties</div>
+        <Button variant="outline" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  if (!properties || properties.length === 0)
+    return <div className="p-4">No properties found</div>;
 
   return (
     <div className="w-full">

--- a/client/src/app/(nondashboard)/search/Map.tsx
+++ b/client/src/app/(nondashboard)/search/Map.tsx
@@ -6,6 +6,8 @@ import { useAppSelector } from "@/state/redux";
 import { useGetPropertiesQuery } from "@/state/api";
 import { Property } from "@/types/prismaTypes";
 import { env } from "../../../../../packages/shared/config/env";
+import Loading from "@/components/Loading";
+import { Button } from "@/components/ui/button";
 
 mapboxgl.accessToken = env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
@@ -16,10 +18,11 @@ const Map = () => {
     data: properties,
     isLoading,
     isError,
+    refetch,
   } = useGetPropertiesQuery(filters);
 
   useEffect(() => {
-    if (isLoading || isError || !properties) return;
+    if (isLoading || isError || !properties || properties.length === 0) return;
 
     const map = new mapboxgl.Map({
       container: mapContainerRef.current!,
@@ -43,8 +46,18 @@ const Map = () => {
     return () => map.remove();
   }, [isLoading, isError, properties, filters.coordinates]);
 
-  if (isLoading) return <>Loading...</>;
-  if (isError || !properties) return <div>Failed to fetch properties</div>;
+  if (isLoading) return <Loading />;
+  if (isError)
+    return (
+      <div className="p-4 flex flex-col items-center gap-2">
+        <div>Failed to fetch properties</div>
+        <Button variant="outline" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  if (!properties || properties.length === 0)
+    return <div className="p-4">No properties found</div>;
 
   return (
     <div className="basis-5/12 grow relative rounded-xl">


### PR DESCRIPTION
## Summary
- replace inline loading text with shared `Loading` component in Listings and Map
- show "No properties found" message when property queries return empty
- add retry button for failed property fetches

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab451972ec832897dccc2739b215f6