### PR TITLE
feat: add confirmation dialog for property deletion

### DIFF
--- a/client/src/app/(dashboard)/managers/properties/page.tsx
+++ b/client/src/app/(dashboard)/managers/properties/page.tsx
@@ -12,6 +12,16 @@ import {
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
 import { Property } from "@/types/prismaTypes";
 
 const Properties = () => {
@@ -78,13 +88,37 @@ const Properties = () => {
               >
                 Edit
               </Button>
-              <Button
-                type="button"
-                className="bg-red-500 text-white hover:bg-red-600"
-                onClick={() => handleDelete(property.id)}
-              >
-                Delete
-              </Button>
+              <Dialog>
+                <DialogTrigger asChild>
+                  <Button
+                    type="button"
+                    className="bg-red-500 text-white hover:bg-red-600"
+                  >
+                    Delete
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Delete Property</DialogTitle>
+                    <DialogDescription>
+                      Are you sure you want to delete this property?
+                    </DialogDescription>
+                  </DialogHeader>
+                  <DialogFooter>
+                    <DialogClose asChild>
+                      <Button variant="outline">Cancel</Button>
+                    </DialogClose>
+                    <DialogClose asChild>
+                      <Button
+                        className="bg-red-500 text-white hover:bg-red-600"
+                        onClick={() => handleDelete(property.id)}
+                      >
+                        Confirm
+                      </Button>
+                    </DialogClose>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
             </div>
             {editingId === property.id && (
               <form


### PR DESCRIPTION
## Summary
- add dialog imports for property delete confirmation
- confirm delete actions through dialog before calling softDeleteProperty

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab451a62f48328848f617570fa3126