### PR TITLE
feat: show manager contact on property page

### DIFF
--- a/client/src/app/(nondashboard)/search/[id]/ContactWidget.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/ContactWidget.tsx
@@ -4,7 +4,7 @@ import { Phone } from "lucide-react";
 import { useRouter } from "next/navigation";
 import React from "react";
 
-const ContactWidget = ({ onOpenModal }: ContactWidgetProps) => {
+const ContactWidget = ({ onOpenModal, managerName, managerPhone }: ContactWidgetProps) => {
   const { data: authUser } = useGetAuthUserQuery();
   const router = useRouter();
 
@@ -24,10 +24,19 @@ const ContactWidget = ({ onOpenModal }: ContactWidgetProps) => {
           <Phone className="text-primary-50" size={15} />
         </div>
         <div>
-          <p>Contact This Property</p>
-          <div className="text-lg font-bold text-primary-800">
-            (424) 340-5574
-          </div>
+          <p>Contact {managerName || "This Property"}</p>
+          {managerPhone ? (
+            <a
+              href={`tel:${managerPhone}`}
+              className="text-lg font-bold text-primary-800"
+            >
+              {managerPhone}
+            </a>
+          ) : (
+            <div className="text-lg font-bold text-primary-800">
+              Contact info not available
+            </div>
+          )}
         </div>
       </div>
       <Button className="w-full" onClick={handleButtonClick}>

--- a/client/src/app/(nondashboard)/search/[id]/page.tsx
+++ b/client/src/app/(nondashboard)/search/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useGetAuthUserQuery } from "@/state/api";
+import { useGetAuthUserQuery, useGetPropertyQuery } from "@/state/api";
 import { useParams } from "next/navigation";
 import React, { useState } from "react";
 import ImagePreviews from "./ImagePreviews";
@@ -15,6 +15,7 @@ const SingleListing = () => {
   const propertyId = Number(id);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { data: authUser } = useGetAuthUserQuery();
+  const { data: property } = useGetPropertyQuery(propertyId);
 
   return (
     <div>
@@ -29,7 +30,11 @@ const SingleListing = () => {
         </div>
 
         <div className="order-1 md:order-2">
-          <ContactWidget onOpenModal={() => setIsModalOpen(true)} />
+          <ContactWidget
+            onOpenModal={() => setIsModalOpen(true)}
+            managerName={property?.manager?.name}
+            managerPhone={property?.manager?.phoneNumber}
+          />
         </div>
       </div>
 

--- a/client/src/state/api.ts
+++ b/client/src/state/api.ts
@@ -114,7 +114,7 @@ export const api = createApi({
       },
     }),
 
-    getProperty: build.query<Property, number>({
+    getProperty: build.query<Property & { manager: Manager }, number>({
       query: (id) => `properties/${id}`,
       providesTags: (result, error, id) => [{ type: "PropertyDetails", id }],
       async onQueryStarted(_, { queryFulfilled }) {

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -71,6 +71,8 @@ declare global {
 
   interface ContactWidgetProps {
     onOpenModal: () => void;
+    managerName?: string;
+    managerPhone?: string;
   }
 
   interface ImagePreviewsProps {

--- a/server/src/controllers/propertyControllers.ts
+++ b/server/src/controllers/propertyControllers.ts
@@ -163,6 +163,7 @@ export const getProperty = async (
       where: { id: Number(id), isDeleted: false },
       include: {
         location: true,
+        manager: true,
       },
     });
 


### PR DESCRIPTION
## Summary
- include property manager details in property query
- forward manager contact info to ContactWidget and display phone link with fallback
- expose contact widget props for manager name and phone

## Testing
- `npm test` (server) *(fails: Missing script)*
- `npm run build` (server)
- `npm test` (client) *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab451ad3ec83288713e146ce057e62